### PR TITLE
fix: improve theme toggle functionality in ThemeContext

### DIFF
--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 
 export const ThemeContext = createContext();
 
@@ -9,20 +9,35 @@ export default function ThemeProvider({ children }) {
     const stored = localStorage.getItem("theme");
     if (stored) {
       setTheme(stored);
-      document.documentElement.classList.toggle("dark", stored === "dark");
+      if (stored === "dark") {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
     } else {
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      setTheme(prefersDark ? "dark" : "light");
-      document.documentElement.classList.toggle("dark", prefersDark);
+      const initialTheme = prefersDark ? "dark" : "light";
+      setTheme(initialTheme);
+      if (prefersDark) {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
     }
   }, []);
 
-  const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
-    document.documentElement.classList.toggle("dark", newTheme === "dark");
-    localStorage.setItem("theme", newTheme);
-  };
+  const toggleTheme = useCallback(() => {
+    setTheme((prevTheme) => {
+      const newTheme = prevTheme === "light" ? "dark" : "light";
+      if (newTheme === "dark") {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+      localStorage.setItem("theme", newTheme);
+      return newTheme;
+    });
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>


### PR DESCRIPTION
## Fixes
Closes #32 - Light/Dark mode toggle not working

## Description
This PR improves the theme toggle functionality in the ThemeContext to fix the issue where the dark mode toggle was not working properly.

## Changes
- Replaced `classList.toggle()` with explicit `classList.add()` and `classList.remove()` methods for more reliable DOM manipulation
- Added `useCallback` hook for the `toggleTheme` function to prevent unnecessary re-renders and improve performance
- Updated `setTheme` to use a callback function ensuring synchronous DOM updates with state changes
- Improved initial theme setup to use explicit class methods instead of toggle
- Fixed potential race conditions in theme updates

## Testing
The theme toggle should now:
1. Immediately switch between light and dark modes when the toggle button is clicked
2. Persist the selected theme in localStorage
3. Respect system preferences on initial load
4. Apply theme changes correctly to the DOM