### PR TITLE
feat: convert legal text to router links in footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -218,9 +218,9 @@ function Footer() {
           </p>
           
           <div className="flex items-center gap-6 text-xs text-gray-500">
-            <span>Terms of Service</span>
-            <span>Privacy Policy</span>
-            <span>Cookie Policy</span>
+            <Link to="/termsandservices" className="hover:text-cyan-400 transition-colors">Terms of Service</Link>
+            <Link to="/privicypolicy" className="hover:text-cyan-400 transition-colors">Privacy Policy</Link>
+            <Link to="/cookie-policy" className="hover:text-cyan-400 transition-colors">Cookie Policy</Link>
           </div>
           
           <div className="flex items-center gap-2 text-xs text-gray-500">


### PR DESCRIPTION
### Description
This PR addresses issue #85 by converting the static legal text items in the footer into clickable router links.

### Changes
- Updated `frontend/src/components/Footer.jsx`
- Replaced `<span>` elements with `<Link>` components for:
  - Terms of Service -> `/termsandservices`
  - Privacy Policy -> `/privicypolicy`
  - Cookie Policy -> `/cookie-policy`
- Added hover states (`hover:text-cyan-400`) to match existing footer links.

### Related Issue
Closes #85

### UI Verification
- [x] Legal items are now clickable.
- [x] Hover effects are consistent with other links.
- [x] Layout and spacing remain unchanged.