### PR TITLE
Fix light theme text visibility issues in Collections filter section

### DIFF
--- a/frontend/src/pages/Collections.jsx
+++ b/frontend/src/pages/Collections.jsx
@@ -106,10 +106,15 @@ const FilterContent = ({
             onChange={(e) => setPriceRange([priceRange[0], parseInt(e.target.value)])}
             className='w-full h-2 bg-slate-300 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer slider-thumb'
           />
-          <div className='flex justify-between mt-3'>
-            <span className='text-gray-400 text-sm font-medium'>${priceRange[0]}</span>
-            <span className='text-white text-sm font-medium'>${priceRange[1]}</span>
-          </div>
+         <div className='flex justify-between mt-3'>
+  <span className='text-slate-700 dark:text-gray-400 text-sm font-medium'>
+    ${priceRange[0]}
+  </span>
+
+  <span className='text-slate-900 dark:text-white text-sm font-semibold'>
+    ${priceRange[1]}
+  </span>
+</div>
         </div>
       </div>
 
@@ -134,7 +139,9 @@ const FilterContent = ({
 
       {/* Sub-Category Filter - Pill Style */}
       <div>
-        <h3 className='text-base font-semibold text-white mb-4'>Sub-Category</h3>
+        <h3 className='font-semibold mb-3 text-slate-900 dark:text-white'>
+  Sub Categories
+</h3>
         <div className='flex flex-wrap gap-2'>
           {subCategories.map((sub, i) => (
             <button


### PR DESCRIPTION
#139  @Nsanjayboruds 
## Changes Made

* Fixed text visibility issues in light theme
* Updated "Sub Categories" heading to support dark/light mode properly


## Result

The filter sidebar and Sub Categories now displays correctly in both dark and light themes without unreadable text.
