### PR TITLE
fix: normalize paginated product API response

### DIFF
--- a/frontend/src/components/CartTotal.jsx
+++ b/frontend/src/components/CartTotal.jsx
@@ -6,13 +6,16 @@ import { RiCoupon2Line, RiArrowRightSLine } from 'react-icons/ri';
 import gsap from 'gsap';
 
 function CartTotal() {
-  const { currency, delivery_fee, getCartAmount } = useContext(shopDataContext);
+  const { currency, delivery_fee, getCartAmount, cartItem } = useContext(shopDataContext);
   const [discountCode, setDiscountCode] = useState('');
   const [hasDiscount, setHasDiscount] = useState(false);
   const [discountAmount, setDiscountAmount] = useState(0);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const subtotal = getCartAmount();
+  const [subtotal, setSubtotal] = useState(0);
+  useEffect(() => {
+    getCartAmount().then(setSubtotal);
+  }, [cartItem]);
   const shippingFee = subtotal > 0 ? delivery_fee : 0;
   const discount = hasDiscount ? Math.min(subtotal * 0.1, 50) : 0; // 10% discount, max $50
   const total = subtotal > 0 ? subtotal + shippingFee - discount : 0;

--- a/frontend/src/components/CartTotal.jsx
+++ b/frontend/src/components/CartTotal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { shopDataContext } from '../context/ShopContext';
 import Title from './Title';
 import { FaShippingFast, FaPercentage, FaGift } from 'react-icons/fa';
@@ -6,16 +6,13 @@ import { RiCoupon2Line, RiArrowRightSLine } from 'react-icons/ri';
 import gsap from 'gsap';
 
 function CartTotal() {
-  const { currency, delivery_fee, getCartAmount, cartItem } = useContext(shopDataContext);
+  const { currency, delivery_fee, getCartAmount } = useContext(shopDataContext);
   const [discountCode, setDiscountCode] = useState('');
   const [hasDiscount, setHasDiscount] = useState(false);
   const [discountAmount, setDiscountAmount] = useState(0);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const [subtotal, setSubtotal] = useState(0);
-  useEffect(() => {
-    getCartAmount().then(setSubtotal);
-  }, [cartItem]);
+  const subtotal = getCartAmount();
   const shippingFee = subtotal > 0 ? delivery_fee : 0;
   const discount = hasDiscount ? Math.min(subtotal * 0.1, 50) : 0; // 10% discount, max $50
   const total = subtotal > 0 ? subtotal + shippingFee - discount : 0;

--- a/frontend/src/context/ShopContext.jsx
+++ b/frontend/src/context/ShopContext.jsx
@@ -10,6 +10,7 @@ export const shopDataContext = createContext();
 function ShopContext({ children }) {
   const [product, setProduct] = useState([]);
   const [pagination, setPagination] = useState({ page: 1, total: 0, pages: 1 });
+  const [loadingProducts, setLoadingProducts] = useState(false);
   const [search, setSearch] = useState("");
   const [showSearch, setShowSearch] = useState(false);
   const [cartItem, setCartItem] = useState({});
@@ -23,6 +24,8 @@ function ShopContext({ children }) {
 
   // Fetch products from server
   const getProducts = async (page = 1, limit = 20) => {
+    if (loadingProducts) return;
+    setLoadingProducts(true);
     try {
       const result = await axios.get(
         `${serverUrl}/api/product/list?page=${page}&limit=${limit}`
@@ -32,6 +35,8 @@ function ShopContext({ children }) {
       setPagination(result.data.pagination || { page: 1, total: 0, pages: 1 });
     } catch (error) {
       console.log("Error fetching products:", error);
+    } finally {
+      setLoadingProducts(false);
     }
   };
 
@@ -120,22 +125,29 @@ function ShopContext({ children }) {
   };
 
 
-  const getCartAmount = () => {
+  const getCartAmount = async () => {
     let totalAmount = 0;
     for (const items in cartItem) {
-      let itemInfo = (product || []).find((product) => product._id === items);
+      let itemInfo = (product || []).find((p) => p._id === items);
+      if (!itemInfo) {
+        try {
+          const res = await axios.get(`${serverUrl}/api/product/${items}`);
+          itemInfo = res.data.product || res.data;
+        } catch (error) {
+          console.log("Could not fetch product for cart item:", items);
+        }
+      }
       for (const item in cartItem[items]) {
         try {
           if (itemInfo && cartItem[items][item] > 0) {
             totalAmount += itemInfo.price * cartItem[items][item];
           }
         } catch (error) {
-
         }
       }
     }
-    return totalAmount
-  }
+    return totalAmount;
+  };
 
   const toggleCompare = (product) => {
     setCompareList(prev => {
@@ -184,6 +196,7 @@ function ShopContext({ children }) {
   const value = {
     product,
     pagination,
+    loadingProducts,
     currency,
     delivery_fee,
     getProducts,

--- a/frontend/src/context/ShopContext.jsx
+++ b/frontend/src/context/ShopContext.jsx
@@ -125,18 +125,10 @@ function ShopContext({ children }) {
   };
 
 
-  const getCartAmount = async () => {
+  const getCartAmount = () => {
     let totalAmount = 0;
     for (const items in cartItem) {
       let itemInfo = (product || []).find((p) => p._id === items);
-      if (!itemInfo) {
-        try {
-          const res = await axios.get(`${serverUrl}/api/product/${items}`);
-          itemInfo = res.data.product || res.data;
-        } catch (error) {
-          console.log("Could not fetch product for cart item:", items);
-        }
-      }
       for (const item in cartItem[items]) {
         try {
           if (itemInfo && cartItem[items][item] > 0) {

--- a/frontend/src/context/ShopContext.jsx
+++ b/frontend/src/context/ShopContext.jsx
@@ -9,6 +9,7 @@ export const shopDataContext = createContext();
 
 function ShopContext({ children }) {
   const [product, setProduct] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, total: 0, pages: 1 });
   const [search, setSearch] = useState("");
   const [showSearch, setShowSearch] = useState(false);
   const [cartItem, setCartItem] = useState({});
@@ -21,11 +22,14 @@ function ShopContext({ children }) {
   const delivery_fee = 40;
 
   // Fetch products from server
-  const getProducts = async () => {
+  const getProducts = async (page = 1, limit = 20) => {
     try {
-      const result = await axios.get(serverUrl + "/api/product/list");
-      console.log("Fetched products:", result.data);
-      setProduct(result.data);
+      const result = await axios.get(
+        `${serverUrl}/api/product/list?page=${page}&limit=${limit}`
+      );
+      const incoming = result.data.products || [];
+      setProduct(prev => page === 1 ? incoming : [...prev, ...incoming]);
+      setPagination(result.data.pagination || { page: 1, total: 0, pages: 1 });
     } catch (error) {
       console.log("Error fetching products:", error);
     }
@@ -119,10 +123,10 @@ function ShopContext({ children }) {
   const getCartAmount = () => {
     let totalAmount = 0;
     for (const items in cartItem) {
-      let itemInfo = product.find((product) => product._id === items);
+      let itemInfo = (product || []).find((product) => product._id === items);
       for (const item in cartItem[items]) {
         try {
-          if (cartItem[items][item] > 0) {
+          if (itemInfo && cartItem[items][item] > 0) {
             totalAmount += itemInfo.price * cartItem[items][item];
           }
         } catch (error) {
@@ -179,6 +183,7 @@ function ShopContext({ children }) {
 
   const value = {
     product,
+    pagination,
     currency,
     delivery_fee,
     getProducts,

--- a/frontend/src/pages/Collections.jsx
+++ b/frontend/src/pages/Collections.jsx
@@ -191,7 +191,7 @@ const FilterContent = ({
 
 function Collections() {
   const [showFilter, setShowFilter] = useState(false);
-  const { product, pagination, getProducts, search, showSearch, compareList, toggleCompare } = useContext(shopDataContext);
+  const { product, pagination, loadingProducts, getProducts, search, showSearch, compareList, toggleCompare } = useContext(shopDataContext);
   const [filterProduct, setFilterProduct] = useState([]);
   const [category, setCategory] = useState([]);
   const [subCategory, setSubCategory] = useState([]);
@@ -479,12 +479,13 @@ function Collections() {
                 {/* Load More Button */}
                 {pagination.page < pagination.pages && (
                   <div className='text-center mt-12'>
-                    <button
-                      onClick={() => getProducts(pagination.page + 1)}
-                      className='px-8 py-3 bg-slate-200 dark:bg-gray-700 hover:bg-slate-300 dark:hover:bg-gray-600 text-slate-800 dark:text-white rounded-lg transition-colors font-semibold'
-                    >
-                      Load More Products
-                    </button>
+  <button
+    onClick={() => getProducts(pagination.page + 1)}
+    disabled={loadingProducts}
+    className='px-8 py-3 bg-slate-200 dark:bg-gray-700 hover:bg-slate-300 dark:hover:bg-gray-600 text-slate-800 dark:text-white rounded-lg transition-colors font-semibold disabled:opacity-50 disabled:cursor-not-allowed'
+  >
+    {loadingProducts ? 'Loading...' : 'Load More Products'}
+  </button>
                   </div>
                 )}
               </>

--- a/frontend/src/pages/Collections.jsx
+++ b/frontend/src/pages/Collections.jsx
@@ -191,7 +191,7 @@ const FilterContent = ({
 
 function Collections() {
   const [showFilter, setShowFilter] = useState(false);
-  const { product, search, showSearch, compareList, toggleCompare } = useContext(shopDataContext);
+  const { product, pagination, getProducts, search, showSearch, compareList, toggleCompare } = useContext(shopDataContext);
   const [filterProduct, setFilterProduct] = useState([]);
   const [category, setCategory] = useState([]);
   const [subCategory, setSubCategory] = useState([]);
@@ -477,9 +477,12 @@ function Collections() {
                 </div>
 
                 {/* Load More Button */}
-                {filterProduct.length > 0 && filterProduct.length % 12 === 0 && (
+                {pagination.page < pagination.pages && (
                   <div className='text-center mt-12'>
-                    <button className='px-8 py-3 bg-slate-200 dark:bg-gray-700 hover:bg-slate-300 dark:hover:bg-gray-600 text-slate-800 dark:text-white rounded-lg transition-colors font-semibold'>
+                    <button
+                      onClick={() => getProducts(pagination.page + 1)}
+                      className='px-8 py-3 bg-slate-200 dark:bg-gray-700 hover:bg-slate-300 dark:hover:bg-gray-600 text-slate-800 dark:text-white rounded-lg transition-colors font-semibold'
+                    >
                       Load More Products
                     </button>
                   </div>

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -8,7 +8,7 @@ import { FaShoppingCart, FaHeart, FaShare, FaStar, FaChevronLeft, FaChevronRight
 
 function ProductDetail() {
   const { productId } = useParams();
-  const { product, currency, addtoCart, addToWishlist } = useContext(shopDataContext);
+  const { product, pagination, currency, addtoCart, addToWishlist } = useContext(shopDataContext);
   const [productData, setProductData] = useState(null);
   const [selectedImage, setSelectedImage] = useState('');
   const [size, setSize] = useState('');
@@ -17,7 +17,7 @@ function ProductDetail() {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   useEffect(() => {
-    const found = product.find(item => item._id === productId);
+    const found = (product || []).find(item => item._id === productId);
     if (found) {
       setProductData(found);
       setSelectedImage(found.image1);
@@ -69,6 +69,16 @@ function ProductDetail() {
   };
 
   if (!productData) {
+    const isFullyLoaded = pagination && pagination.page >= pagination.pages;
+    if (isFullyLoaded) {
+      return (
+        <div className="min-h-screen bg-gradient-to-br from-slate-100 to-sky-100 dark:from-[#0f172a] dark:to-[#0c4a6e] flex items-center justify-center">
+          <div className="text-slate-900 dark:text-white text-center">
+            <p className="text-lg">Product not found.</p>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-100 to-sky-100 dark:from-[#0f172a] dark:to-[#0c4a6e] flex items-center justify-center">
         <div className="text-slate-900 dark:text-white text-center">


### PR DESCRIPTION
## Problem
GET /api/product/list returns a paginated response shape but the frontend 
was consuming it as a flat array, causing crashes across the app.

## Changes
- ShopContext: extract result.data.products instead of result.data
- ShopContext: add pagination state, update getProducts with page/limit support
- ShopContext: guard getCartAmount against undefined product/itemInfo
- Collections: wire Load More button to pagination
- ProductDetail: split loading vs not-found states

## Files Changed
- frontend/src/context/ShopContext.jsx
- frontend/src/pages/Collections.jsx
- frontend/src/pages/ProductDetail.jsx

Closes #145 