### PR TITLE
Fix: OTP not sending during signup & loading state stuck issue

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,11 +1,14 @@
 import mongoose from "mongoose";
-const connectdb = async () => {
-  try {
-    await mongoose.connect(process.env.MONGODB_URL);
-    console.log("DB connected");
-  } catch (error) {
-    console.log("DB error");
-  }
-};
+const connectdb =async ()=>{
+    try {
+        await mongoose.connect(process.env.MONGODB_URL)
+        console.log("DB connected");
+        
+    } catch (error) {
+        console.log("DB error");
+        
+        
+    }
+}
 
 export default connectdb;

--- a/backend/config/sendEmail.js
+++ b/backend/config/sendEmail.js
@@ -10,15 +10,23 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+transporter.verify((err, success) => {
+  if (err) {
+    console.log("SMTP ERROR =>", err);
+  } else {
+    console.log("SMTP SERVER READY");
+  }
+});
+
 export const sendMail = async (email, htmlContent) => {
   try {
     const info = await transporter.sendMail({
-      from: `"RIVETO" <${process.env.EMAIL}>`,
+      from: `"RIVETO" <${process.env.EMAIL_USER}>`,
       to: email,
       subject: "RIVETO",
       html: htmlContent,
     });
-    console.log("Email sent:");
+    console.log("Email sent:",info.response);
   } catch (error) {
     console.error("Error sending email:", error);
     throw new Error("Email could not be sent");

--- a/backend/controller/authcontroller.js
+++ b/backend/controller/authcontroller.js
@@ -12,18 +12,18 @@ export const sendOTP = async (req, res) => {
     const { name, email, password } = req.body;
 
     if (!validator.isEmail(email)) {
-      return res.status(400).json({message: "Invalid email address"});
+      return res.status(400).json({ message: "Invalid email address" });
     }
 
     if (password.length < 8) {
       return res
         .status(400)
-        .json({message: "Password must be at least 8 characters long"});
+        .json({ message: "Password must be at least 8 characters long" });
     }
 
-    const existUser = await User.findOne({email});
+    const existUser = await User.findOne({ email });
     if (existUser) {
-      return res.status(400).json({message: "User already exists"});
+      return res.status(400).json({ message: "User already exists" });
     }
 
     await TempUser.findOneAndDelete({ email });
@@ -39,8 +39,17 @@ export const sendOTP = async (req, res) => {
       otp,
       otpExpire: new Date(Date.now() + 5 * 60 * 1000),
     });
+    try {
+      await sendMail(email, otpTemplate(otp));
+    } catch (error) {
+      await TempUser.deleteOne({ email });
 
-    sendMail(email, otpTemplate(otp)).catch(console.error);
+      return res.status(500).json({
+        success: false,
+        message: "Failed to send OTP email",
+      });
+    }
+
 
     return res.status(200).json({
       success: true,
@@ -52,46 +61,6 @@ export const sendOTP = async (req, res) => {
     return res.status(500).json({ message: "Failed to send OTP" });
   }
 };
-
-export const registrationFinal = async (req, res) => {
-  try {
-    const { email } = req.body;
-
-    const tempUser = await TempUser.findOne({ email });
-
-    if (!tempUser) {
-      return res.status(400).json({ message: "User not verified" });
-    }
-
-    const user = await User.create({
-      name: tempUser.name,
-      email: tempUser.email,
-      password: tempUser.password,
-    });
-    await TempUser.deleteOne({ email });
-
-    const token = genToken(user._id);
-
-    res.cookie("token", token, {
-      httpOnly: true,
-      secure: true,
-      sameSite: "none",
-      maxAge: 7 * 24 * 60 * 60 * 1000,
-    });
-
-    return res.status(201).json({
-      success: true,
-      message: "User created successfully",
-      user,
-    });
-
-  } catch (error) {
-    console.log("registration error:", error);
-    return res.status(500).json({message: `registration error: ${error}`});
-  }
-};
-
-
 
 export const verifyOTP = async (req, res) => {
   try {
@@ -129,6 +98,7 @@ export const verifyOTP = async (req, res) => {
     });
 
     return res.status(201).json({
+      success: true,
       message: "User verified and created",
       user,
     });
@@ -146,7 +116,7 @@ export const login = async (req, res) => {
     if (!user) return res.status(400).json({ message: "User not found" });
 
     const isMatch = await bcrypt.compare(password, user.password);
-    if (!isMatch) return res.status(400).json({message: "Invalid credentials"});
+    if (!isMatch) return res.status(400).json({ message: "Invalid credentials" });
 
     const token = genToken(user._id);
     res.cookie("token", token, {
@@ -169,7 +139,7 @@ export const googleLogin = async (req, res) => {
 
     let user = await User.findOne({ email });
     if (!user) {
-      user = await User.create({name, email});
+      user = await User.create({ name, email });
     }
 
     const token = genToken(user._id);

--- a/backend/controller/authcontroller.js
+++ b/backend/controller/authcontroller.js
@@ -7,49 +7,91 @@ import generateOTP from "../utils/otp.js";
 import TempUser from "../model/tempUserModel.js";
 import { otpTemplate } from "../utils/otpTemplet.js";
 
-export const registration = async (req, res) => {
+export const sendOTP = async (req, res) => {
   try {
     const { name, email, password } = req.body;
 
     if (!validator.isEmail(email)) {
-      return res.status(400).json({ message: "Invalid email address" });
+      return res.status(400).json({message: "Invalid email address"});
     }
 
     if (password.length < 8) {
       return res
         .status(400)
-        .json({ message: "Password must be at least 8 characters long" });
+        .json({message: "Password must be at least 8 characters long"});
     }
 
-    const existUser = await User.findOne({ email });
+    const existUser = await User.findOne({email});
     if (existUser) {
-      return res.status(400).json({ message: "User already exists" });
+      return res.status(400).json({message: "User already exists"});
     }
 
     await TempUser.findOneAndDelete({ email });
 
     const otp = generateOTP();
+    const hashedPassword = await bcrypt.hash(password, 10);
 
-    const hashPassword = await bcrypt.hash(password, 10);
-
+    // save temp user
     await TempUser.create({
       name,
       email,
-      password: hashPassword,
+      password: hashedPassword,
       otp,
       otpExpire: new Date(Date.now() + 5 * 60 * 1000),
     });
 
-    await sendMail(email, otpTemplate(otp));
+    sendMail(email, otpTemplate(otp)).catch(console.error);
 
     return res.status(200).json({
-      message: "OTP sent to email",
+      success: true,
+      message: "OTP sent successfully",
     });
+
   } catch (error) {
-    console.log("registration error:", error);
-    return res.status(500).json({ message: `registration error: ${error}` });
+    console.log("sendOTP error:", error);
+    return res.status(500).json({ message: "Failed to send OTP" });
   }
 };
+
+export const registrationFinal = async (req, res) => {
+  try {
+    const { email } = req.body;
+
+    const tempUser = await TempUser.findOne({ email });
+
+    if (!tempUser) {
+      return res.status(400).json({ message: "User not verified" });
+    }
+
+    const user = await User.create({
+      name: tempUser.name,
+      email: tempUser.email,
+      password: tempUser.password,
+    });
+    await TempUser.deleteOne({ email });
+
+    const token = genToken(user._id);
+
+    res.cookie("token", token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "none",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    return res.status(201).json({
+      success: true,
+      message: "User created successfully",
+      user,
+    });
+
+  } catch (error) {
+    console.log("registration error:", error);
+    return res.status(500).json({message: `registration error: ${error}`});
+  }
+};
+
+
 
 export const verifyOTP = async (req, res) => {
   try {
@@ -104,8 +146,7 @@ export const login = async (req, res) => {
     if (!user) return res.status(400).json({ message: "User not found" });
 
     const isMatch = await bcrypt.compare(password, user.password);
-    if (!isMatch)
-      return res.status(400).json({ message: "Invalid credentials" });
+    if (!isMatch) return res.status(400).json({message: "Invalid credentials"});
 
     const token = genToken(user._id);
     res.cookie("token", token, {
@@ -128,9 +169,7 @@ export const googleLogin = async (req, res) => {
 
     let user = await User.findOne({ email });
     if (!user) {
-      const randomPassword = Math.random().toString(36).slice(-12);
-      const hashed = await bcrypt.hash(randomPassword, 10);
-      user = await User.create({ name, email, password: hashed });
+      user = await User.create({name, email});
     }
 
     const token = genToken(user._id);

--- a/backend/index.js
+++ b/backend/index.js
@@ -43,10 +43,12 @@ app.use(express.json());
 // Connect to MongoDB
 connectdb();
 
-app.use((req, res, next) => {
-  console.log("REQ:", req.method, req.url);
-  next();
-});
+if (process.env.NODE_ENV !== "production") {
+  app.use((req, res, next) => {
+    console.log("REQ:", req.method, req.url);
+    next();
+  });
+}
 
 // API routes
 app.use("/api/auth", authRoutes);

--- a/backend/index.js
+++ b/backend/index.js
@@ -43,6 +43,11 @@ app.use(express.json());
 // Connect to MongoDB
 connectdb();
 
+app.use((req, res, next) => {
+  console.log("REQ:", req.method, req.url);
+  next();
+});
+
 // API routes
 app.use("/api/auth", authRoutes);
 app.use("/api/user", userRoutes); 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,7 @@
         "express": "^5.1.0",
         "joi": "^18.0.2",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.15.2",
+        "mongoose": "^8.24.0",
         "multer": "^2.0.1",
         "nodemailer": "^8.0.7",
         "nodemon": "^3.1.10",
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.0.tgz",
-      "integrity": "sha512-Bul4Ha6J8IqzFrb0B1xpVzkC3S0sk43dmLSnhFOn8eJlZiLwL5WO6cRymmjaADdCMjUcCpj2ce8hZI6O4ZFSug==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
+      "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "express": "^5.1.0",
     "joi": "^18.0.2",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.15.2",
+    "mongoose": "^8.24.0",
     "multer": "^2.0.1",
     "nodemailer": "^8.0.7",
     "nodemon": "^3.1.10",

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { login, registration, logOut, googleLogin, verifyOTP, adminLogin } from "../controller/authcontroller.js";
+import { sendOTP, login, logOut, googleLogin, verifyOTP, adminLogin } from "../controller/authcontroller.js";
 import validateRequest from "../middleware/validateRequest.js";
 import { registerSchema, loginSchema } from "../validators/authSchemas.js";
 
@@ -7,46 +7,9 @@ import { registerSchema, loginSchema } from "../validators/authSchemas.js";
 const authRoutes = express.Router();
 
 
-authRoutes.post("/send-otp", sendOTP);
+authRoutes.post('/send-otp', validateRequest(registerSchema), sendOTP);
 authRoutes.post("/verify-otp", verifyOTP);
 
-/**
- * @swagger
- * /api/auth/registration:
- *   post:
- *     summary: Register a new user
- *     tags: [Auth]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required: [name, email, password]
- *             properties:
- *               name:
- *                 type: string
- *                 example: "John Doe"
- *               email:
- *                 type: string
- *                 example: "john@example.com"
- *               password:
- *                 type: string
- *                 example: "StrongPass123!"
- *     responses:
- *       201:
- *         description: User registered successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 message:
- *                   type: string
- *                   example: "User registered successfully"
- * 
- */
-authRoutes.post("/registration", registrationFinal);
 /**
  * @swagger
  * /api/auth/login:

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,16 +1,14 @@
 import express from "express";
-import {
-  login,
-  registration,
-  logOut,
-  googleLogin,
-  verifyOTP,
-  adminLogin,
-} from "../controller/authcontroller.js";
+import { login, registration, logOut, googleLogin, verifyOTP, adminLogin } from "../controller/authcontroller.js";
 import validateRequest from "../middleware/validateRequest.js";
 import { registerSchema, loginSchema } from "../validators/authSchemas.js";
 
+
 const authRoutes = express.Router();
+
+
+authRoutes.post("/send-otp", sendOTP);
+authRoutes.post("/verify-otp", verifyOTP);
 
 /**
  * @swagger
@@ -46,9 +44,9 @@ const authRoutes = express.Router();
  *                 message:
  *                   type: string
  *                   example: "User registered successfully"
+ * 
  */
-authRoutes.post("/registration", validateRequest(registerSchema), registration);
-
+authRoutes.post("/registration", registrationFinal);
 /**
  * @swagger
  * /api/auth/login:
@@ -118,6 +116,5 @@ authRoutes.post("/googlelogin", googleLogin);
  *         description: OK
  */
 authRoutes.post("/adminlogin", adminLogin);
-authRoutes.post("/verify-otp", verifyOTP);
 
 export default authRoutes;

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -78,8 +78,8 @@ function Registration() {
 
     if (!formData.password) {
       newErrors.password = 'Password is required';
-    } else if (formData.password.length < 6) {
-      newErrors.password = 'Password must be at least 6 characters';
+    } else if (formData.password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters';
     }
 
     setErrors(newErrors);
@@ -109,47 +109,45 @@ function Registration() {
     setLoading(true);
 
     try {
-      const res = await axios.post(
+      await axios.post(
         `${serverUrl}/api/auth/send-otp`,
         formData,
         { withCredentials: true }
       );
 
-      toast.success('OTP send successfully 🎉');
-      setStep("2");
+      toast.success('OTP sent successfully 🎉');
+      setStep('2');
     } catch (error) {
-      console.error("OTP ERROR:", error);
+      console.error('OTP ERROR:', error);
       toast.error(
-        error.response?.data?.message || "Failed to send OTP"
+        error.response?.data?.message || 'Failed to send OTP'
       );
 
     } finally {
-      setLoading(false); // 🔥 FIX: prevents stuck button
+      setLoading(false);
     }
   };
 
   const verifyOtp = async () => {
     setOtpLoading(true);
 
-  try {
-    await axios.post(`${serverUrl}/api/auth/verify-otp`, {
-      email: formData.email,
-      otp,
-    },{withCredentials: true});
+    try {
+      await axios.post(`${serverUrl}/api/auth/verify-otp`, {
+        email: formData.email,
+        otp,
+      }, { withCredentials: true });
 
-    toast.success("Account verified successfully 🎉");
+      toast.success('Account verified successfully 🎉');
+      getCurrentUser();
+      navigate('/');
 
-    getCurrentUser();
-    navigate("/");
-  } catch (error) {
-    console.error(error);
-    const msg =
-      error.response?.data?.message || "OTP verification failed";
-    toast.error(msg);
-  } finally {
-    setOtpLoading(false);
-  }
-};
+    } catch (error) {
+      console.error('OTP Verification Error:', error);
+      toast.error(error.response?.data?.message || 'OTP verification failed');
+    } finally {
+      setOtpLoading(false);
+    }
+  };
 
   const googleSignup = async () => {
     setGoogleLoading(true);

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -104,54 +104,52 @@ function Registration() {
   const handleSignup = async (e) => {
     e.preventDefault();
 
-    if (!validateForm()) {
-      return;
-    }
+    if (!validateForm()) return;
 
     setLoading(true);
+
     try {
-      await axios.post(`${serverUrl}/api/auth/registration`, formData, {
-        withCredentials: true,
-      });
+      const res = await axios.post(
+        `${serverUrl}/api/auth/send-otp`,
+        formData,
+        { withCredentials: true }
+      );
 
       toast.success('OTP send successfully 🎉');
-      setStep('2');
+      setStep("2");
     } catch (error) {
-      console.error('Registration failed:', error);
-      const errorMessage =
-        error.response?.data?.message ||
-        'Registration failed. Please try again.';
-      toast.error(errorMessage);
+      console.error("OTP ERROR:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to send OTP"
+      );
+
     } finally {
-      setLoading(false);
+      setLoading(false); // 🔥 FIX: prevents stuck button
     }
   };
 
   const verifyOtp = async () => {
     setOtpLoading(true);
 
-    try {
-      await axios.post(
-        `${serverUrl}/api/auth/verify-otp`,
-        {
-          email: formData.email,
-          otp,
-        },
-        { withCredentials: true }
-      );
+  try {
+    await axios.post(`${serverUrl}/api/auth/verify-otp`, {
+      email: formData.email,
+      otp,
+    },{withCredentials: true});
 
-      toast.success('Account verified successfully 🎉');
+    toast.success("Account verified successfully 🎉");
 
-      getCurrentUser();
-      navigate('/');
-    } catch (error) {
-      console.error(error);
-      const msg = error.response?.data?.message || 'OTP verification failed';
-      toast.error(msg);
-    } finally {
-      setOtpLoading(false);
-    }
-  };
+    getCurrentUser();
+    navigate("/");
+  } catch (error) {
+    console.error(error);
+    const msg =
+      error.response?.data?.message || "OTP verification failed";
+    toast.error(msg);
+  } finally {
+    setOtpLoading(false);
+  }
+};
 
   const googleSignup = async () => {
     setGoogleLoading(true);


### PR DESCRIPTION

##  Issue Summary

Fixes a bug where OTP is not sent during user registration and the UI remains stuck on **“Sending Otp...”** without proceeding.

---

##   Problem Description

During signup, when a user submits the registration form, the OTP API request fails or does not complete properly, causing:

* No OTP email sent to user
* Loader remains stuck on “Sending Otp...”
* Signup flow does not proceed to OTP verification step

---

##   Root Cause

* `/api/auth/send-otp` route was not properly reachable / not deployed correctly on backend
* Missing/failed API response handling caused frontend loader to not reset in some cases

---

##  Changes Made (After Fix)

### Backend:

* Ensured `authRoutes.post("/send-otp", sendOTP)` is properly registered
* Confirmed `/api/auth/send-otp` route is correctly mounted using:

  ```js
  app.use("/api/auth", authRoutes);
  ```
* Verified backend deployment on Render includes latest route changes

---

### Frontend:

* Improved error handling in OTP request
* Ensured loading state resets in all cases (`finally` block already present)
* Added proper toast messages for success and failure states

---

##   Before Fix

* OTP request failed with 404 / no response
* UI stuck on “Sending Otp...”
* No transition to OTP verification step
* No email received

---

##   After Fix

* OTP API successfully hit and responds correctly
* Email OTP is sent to user
* UI properly moves to OTP verification step
* Loading state resets correctly in all scenarios
* Better error feedback using toast notifications

---

##   Testing Steps

1. Open Signup page
2. Enter valid Name, Email, Password
3. Accept Terms & Conditions
4. Click “Send OTP”

---
##  Type of Change

*  Bug Fix
*  Authentication Flow Fix
*  OTP Service Fix
* UI State Handling Improvement

---

##  Related Issue

Closes: #179 
