### PR TITLE
move contributors into footer and add navigation link to it

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -74,11 +74,11 @@ function Footer() {
       className="w-full bg-slate-100 dark:bg-gradient-to-b dark:from-gray-900 dark:to-gray-950 text-gray-700 dark:text-gray-300 border-t border-gray-200 dark:border-gray-800 relative overflow-hidden transition-colors duration-300"
     >
       {/* Background Pattern - Faint in light mode */}
-      <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCI+CiAgPHBhdGggZD0iTTAgMGg2MHY2MEgweiIgZmlsbD0ibm9uZSIvPgogIDxwYXRoIGQ9Ik0zMCAzMG0tMjggMGEyOCwyOCAwIDEsMSA1NiwwYTI4LDI4IDAgMSwxIC01NiwwIiBzdHJva2U9InJnYmEoMjU1LDI1NSwyNTUsMC4wMykiIHN0cm9rZS13aWR0aD0iMC41IiBmaWxsPSJub25lIi8+Cjwvc3ZnPg==')] opacity-20"></div>
+      <div className="absolute inset-0 pointer-events-none bg-[url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCI+CiAgPHBhdGggZD0iTTAgMGg2MHY2MEgweiIgZmlsbD0ibm9uZSIvPgogIDxwYXRoIGQ9Ik0zMCAzMG0tMjggMGEyOCwyOCAwIDEsMSA1NiwwYTI4LDI4IDAgMSwxIC01NiwwIiBzdHJva2U9InJnYmEoMjU1LDI1NSwyNTUsMC4wMykiIHN0cm9rZS13aWR0aD0iMC41IiBmaWxsPSJub25lIi8+Cjwvc3ZnPg==')] opacity-20"></div>
 
       {/* Decorative Elements - Hidden in light mode or adjusted */}
-      <div className="absolute -top-20 -right-20 w-40 h-40 bg-cyan-500/10 rounded-full blur-3xl hidden dark:block"></div>
-      <div className="absolute -bottom-20 -left-20 w-40 h-40 bg-blue-500/10 rounded-full blur-3xl hidden dark:block"></div>
+      <div className="absolute -top-20 -right-20 w-40 h-40 bg-cyan-500/10 rounded-full blur-3xl hidden dark:block pointer-events-none"></div>
+      <div className="absolute -bottom-20 -left-20 w-40 h-40 bg-blue-500/10 rounded-full blur-3xl hidden dark:block pointer-events-none"></div>
 
       {/* Main Footer Content */}
       <div className="max-w-7xl mx-auto py-16 px-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10 relative z-10">
@@ -147,6 +147,7 @@ function Footer() {
             {[
               { name: 'Home', to: '/' },
               { name: 'About Us', to: '/about' },
+              { name: 'Contributors', to: '/contributors' },
               { name: 'Products', to: '/product' },
               { name: 'Collections', to: '/collection' },
               { name: 'New Arrivals', to: '/new-arrivals' },
@@ -155,7 +156,7 @@ function Footer() {
               <li key={index}>
                 <Link
                   to={item.to}
-                  className="text-sm text-gray-600 dark:text-gray-400 hover:text-cyan-400 transition-colors duration-300 flex items-center gap-2 group"
+                  className="relative z-20 text-sm text-gray-600 dark:text-gray-400 hover:text-cyan-400 transition-colors duration-300 flex items-center gap-2 group"
                 >
                   <span className="w-1 h-1 bg-cyan-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"></span>
                   {item.name}

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -10,7 +10,7 @@ import { IoSearchCircleOutline, IoSearchCircleSharp } from 'react-icons/io5';
 import { FaUserCircle } from 'react-icons/fa';
 import { MdOutlineShoppingCart, MdLogout } from 'react-icons/md';
 import { IoMdHome } from 'react-icons/io';
-import { HiOutlineCollection, HiOutlineUserGroup } from 'react-icons/hi';
+import { HiOutlineCollection } from 'react-icons/hi';
 import { RiContactsLine } from 'react-icons/ri';
 import { BsMoon, BsSun, BsSearch, BsBoxSeam } from 'react-icons/bs';
 import { FiInfo, FiUser, FiLogIn } from 'react-icons/fi';
@@ -147,7 +147,6 @@ function Nav() {
             {[
               { label: 'Home', path: '/' },
               { label: 'Collection', path: '/collection' },
-              { label: 'Contributors', path: '/contributors' },
               { label: 'Recommendations', path: '/recommendations' },
               { label: 'About', path: '/about' },
               { label: 'Contact', path: '/contact' },
@@ -495,11 +494,6 @@ px-3
           {/* Right Side */}
           <div className="flex items-center gap-2">
             {[
-              {
-                icon: HiOutlineUserGroup,
-                label: 'Creators',
-                path: '/contributors',
-              },
               {
                 icon: RiContactsLine,
                 label: 'Contact',


### PR DESCRIPTION
Moved contributors section into the footer to make navbar clean and only applicable to shopping.

Screenshots:
<img width="1416" height="764" alt="image" src="https://github.com/user-attachments/assets/fee31c3d-e6bf-49ca-aba3-1eea9d8e18e7" />
<img width="1414" height="460" alt="image" src="https://github.com/user-attachments/assets/d8a68771-e2f1-4bdd-808c-53e31b4a32fc" />
