### PR TITLE
fix: add missing leading slash to order routes

### DIFF
--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -10,8 +10,8 @@ import adminAuth from "../middleware/adminAuth.js";
 
 const orderRoutes = express.Router();
 
-orderRoutes.post("placeorder", isAuth, placeOrder);
-orderRoutes.post("userorder", isAuth, userOrders);
+orderRoutes.post("/placeorder", isAuth, placeOrder);
+orderRoutes.post("/userorder", isAuth, userOrders);
 
 orderRoutes.post("/list", adminAuth, allOrders);
 orderRoutes.post("/status", adminAuth, updateStatus);


### PR DESCRIPTION
## Summary
Fixes a routing bug where two order routes were missing a leading slash, making them completely unreachable and causing 404 errors for all order placements.

## Description
In `backend/routes/orderRoutes.js`, the routes for `placeorder` and `userorder` were defined without a leading `/`, which means Express could never match them.
**Changed `backend/routes/orderRoutes.js` lines 13–14:**
Before:
```js
orderRoutes.post("placeorder", isAuth, placeOrder);
orderRoutes.post("userorder", isAuth, userOrders);
```
After:
```js
orderRoutes.post("/placeorder", isAuth, placeOrder);
orderRoutes.post("/userorder", isAuth, userOrders);
```

## Related Issue
Fixes #226
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated if required