### PR TITLE
fix: hash OTPs before storing in Database

### DIFF
--- a/backend/controller/authcontroller.js
+++ b/backend/controller/authcontroller.js
@@ -29,15 +29,16 @@ export const sendOTP = async (req, res) => {
 
     await TempUser.findOneAndDelete({ email });
 
-    const otp = generateOTP();
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const otp = generateOTP().toString();
 
-    // save temp user
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedOTP = await bcrypt.hash(otp, 10);
+
     await TempUser.create({
       name,
       email,
       password: hashedPassword,
-      otp,
+      otp: hashedOTP,
       otpExpire: new Date(Date.now() + 5 * 60 * 1000),
     });
     try {
@@ -72,12 +73,21 @@ export const verifyOTP = async (req, res) => {
       return res.status(400).json({ message: "User not found or OTP expired" });
     }
 
-    if (tempUser.otp !== otp) {
-      return res.status(400).json({ message: "Invalid OTP" });
+    if (tempUser.otpExpire < new Date()) {
+      return res.status(400).json({
+        message: "OTP expired",
+      });
     }
 
-    if (tempUser.otpExpire < new Date()) {
-      return res.status(400).json({ message: "OTP expired" });
+    const isValidOTP = await bcrypt.compare(
+      otp.toString(),
+      tempUser.otp
+    );
+
+    if (!isValidOTP) {
+      return res.status(400).json({
+        message: "Invalid OTP",
+      });
     }
 
     const user = await User.create({


### PR DESCRIPTION
# Pull Request

## Summary

Improve authentication security by hashing OTPs before storing them in the database and verifying them using bcrypt during OTP validation.

## Description

Previously, OTPs were stored in plaintext in the `TempUser` collection and compared directly during verification. This exposed active OTPs to anyone with database access.

### Changes Made

* Hash OTPs using `bcrypt` before saving them to the database.
* Verify OTPs using `bcrypt.compare()` instead of direct string comparison.
* Check OTP expiration before performing hash verification to avoid unnecessary processing.
* Preserved the existing OTP generation, email delivery, and user registration flow.

### Benefits

* Prevents exposure of active OTPs through database access.
* Aligns OTP handling with password security best practices.
* Improves overall authentication security with minimal impact on performance.

## Related Issue

Fixes #259 

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] UI/UX improvement
* [ ] Refactoring

## Checklist

* [x] Code follows project guidelines
* [x] Tested locally
* [x] No console errors
* [ ] Documentation updated if required
