### PR TITLE
Fix: clear pending setTimeout calls in NewsletterBox to prevent memory leak

### DIFF
--- a/frontend/src/components/NewLetterBox.jsx
+++ b/frontend/src/components/NewLetterBox.jsx
@@ -11,6 +11,8 @@ function NewsletterBox() {
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
   const scratchPercentageRef = useRef(0);
+  const timeoutRef1 = useRef(null);
+  const timeoutRef2 = useRef(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -127,17 +129,24 @@ function NewsletterBox() {
     }
 
     // Simulate API call
-    setTimeout(() => {
+    timeoutRef1.current = setTimeout(() => {
       setIsSubscribed(true);
       toast.success('Welcome to exclusive membership!');
 
       // Reset after 5 seconds
-      setTimeout(() => {
+      timeoutRef2.current = setTimeout(() => {
         setIsSubscribed(false);
         setEmail('');
       }, 5000);
     }, 1000);
   };
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutRef1.current);
+      clearTimeout(timeoutRef2.current);
+    };
+  }, []);
 
   return (
     <section className="w-full bg-gradient-to-b from-white to-gray-50 dark:from-[#0B0F1A] dark:to-[#0B0F1A] px-4 py-16 md:py-20 transition-colors duration-300">


### PR DESCRIPTION

## Summary
Fixes a memory leak caused by uncleared `setTimeout` calls in `handleSubmit` inside `NewsletterBox.jsx`.

## Description
`handleSubmit` used two nested `setTimeout` calls to simulate an API call and reset the form afterward, but neither timer was stored or cleared. If a user submitted the form and navigated away (unmounting the component) before these timers fired, React logged a "state update on unmounted component" warning, indicating a memory leak.

This PR fixes it by:
- Adding `timeoutRef1` and `timeoutRef2` using `useRef` to store the IDs returned by `setTimeout`
- Assigning both `setTimeout` calls to these refs
- Adding a `useEffect` with an empty dependency array that clears both timeouts on component unmount

```js
const timeoutRef1 = useRef(null);
const timeoutRef2 = useRef(null);

const handleSubmit = (e) => {
  e.preventDefault();

  if (!email) {
    toast.error('Please enter your email address');
    return;
  }

  timeoutRef1.current = setTimeout(() => {
    setIsSubscribed(true);
    toast.success('Welcome to exclusive membership!');

    timeoutRef2.current = setTimeout(() => {
      setIsSubscribed(false);
      setEmail('');
    }, 5000);
  }, 1000);
};

useEffect(() => {
  return () => {
    clearTimeout(timeoutRef1.current);
    clearTimeout(timeoutRef2.current);
  };
}, []);
```

## Related Issue
Fixes #300

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required