### PR TITLE
Fix dark mode on Recommendations page

### DIFF
--- a/frontend/src/components/IssueRecommendations.jsx
+++ b/frontend/src/components/IssueRecommendations.jsx
@@ -80,34 +80,34 @@ export default function IssueRecommendations() {
 
   const difficultyColor = (label) => {
     if (label === 'Easy')
-      return 'bg-emerald-100 text-emerald-700 border-emerald-200';
+      return 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800';
     if (label === 'Medium')
-      return 'bg-amber-100 text-amber-700 border-amber-200';
-    return 'bg-rose-100 text-rose-700 border-rose-200';
+      return 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800';
+    return 'bg-rose-100 text-rose-700 border-rose-200 dark:bg-rose-900/30 dark:text-rose-300 dark:border-rose-800';
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-cyan-50 px-4 py-10 sm:px-6 lg:px-8">
+    <div className="px-4 py-10 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
-        <div className="mb-8 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-600">
+        <div className="page-card mb-8 p-6 shadow-slate-200/60 dark:shadow-none">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-600 dark:text-cyan-400">
             Contributor discovery
           </p>
-          <h1 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
             Recommended issues
           </h1>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 sm:text-base">
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 dark:text-gray-400 sm:text-base">
             Find beginner-friendly and relevant GitHub issues ranked by label
             signals, stack matching, and contribution history keywords.
           </p>
 
           <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             <label className="xl:col-span-2">
-              <span className="mb-2 block text-sm font-medium text-slate-700">
+              <span className="mb-2 block text-sm font-medium text-slate-700 dark:text-gray-300">
                 Search
               </span>
               <input
-                className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none transition focus:border-cyan-500 focus:ring-4 focus:ring-cyan-100"
+                className="page-input w-full transition focus:border-cyan-500 focus:ring-4 focus:ring-cyan-100 dark:focus:ring-cyan-900/40 dark:placeholder-gray-500"
                 placeholder="Search issues, labels, or descriptions"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
@@ -115,11 +115,11 @@ export default function IssueRecommendations() {
             </label>
 
             <label>
-              <span className="mb-2 block text-sm font-medium text-slate-700">
+              <span className="mb-2 block text-sm font-medium text-slate-700 dark:text-gray-300">
                 Recent work keywords
               </span>
               <input
-                className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none transition focus:border-cyan-500 focus:ring-4 focus:ring-cyan-100"
+                className="page-input w-full transition focus:border-cyan-500 focus:ring-4 focus:ring-cyan-100 dark:focus:ring-cyan-900/40 dark:placeholder-gray-500"
                 placeholder="auth, cart, ui"
                 value={history}
                 onChange={(event) => setHistory(event.target.value)}
@@ -127,7 +127,7 @@ export default function IssueRecommendations() {
             </label>
 
             <div>
-              <span className="mb-2 block text-sm font-medium text-slate-700">
+              <span className="mb-2 block text-sm font-medium text-slate-700 dark:text-gray-300">
                 Difficulty
               </span>
               <div className="flex flex-wrap gap-2">
@@ -138,8 +138,8 @@ export default function IssueRecommendations() {
                     onClick={() => setLevel(item.value)}
                     className={`rounded-full px-4 py-2 text-sm font-medium transition ${
                       level === item.value
-                        ? 'bg-slate-900 text-white shadow-lg shadow-slate-300'
-                        : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-300 hover:text-cyan-700'
+                        ? 'bg-slate-900 text-white shadow-lg shadow-slate-300 dark:bg-cyan-600 dark:shadow-cyan-900/30'
+                        : 'border border-slate-200 bg-white text-slate-600 hover:border-cyan-300 hover:text-cyan-700 dark:border-[#1f2a44] dark:bg-[#0f172a] dark:text-gray-300 dark:hover:border-cyan-500 dark:hover:text-cyan-400'
                     }`}
                   >
                     {item.label}
@@ -159,8 +159,8 @@ export default function IssueRecommendations() {
                   onClick={() => toggleStack(tech)}
                   className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
                     active
-                      ? 'border-cyan-600 bg-cyan-600 text-white shadow-lg shadow-cyan-200'
-                      : 'border-slate-200 bg-white text-slate-600 hover:border-cyan-300 hover:text-cyan-700'
+                      ? 'border-cyan-600 bg-cyan-600 text-white shadow-lg shadow-cyan-200 dark:shadow-cyan-900/30'
+                      : 'border-slate-200 bg-white text-slate-600 hover:border-cyan-300 hover:text-cyan-700 dark:border-[#1f2a44] dark:bg-[#0f172a] dark:text-gray-300 dark:hover:border-cyan-500 dark:hover:text-cyan-400'
                   }`}
                 >
                   {tech}
@@ -177,10 +177,10 @@ export default function IssueRecommendations() {
         )}
         {error && (
           <div className="py-10">
-            <ErrorState 
-              title="Failed to load recommendations" 
-              message={error} 
-              onRetry={() => setRetryCount((prev) => prev + 1)} 
+            <ErrorState
+              title="Failed to load recommendations"
+              message={error}
+              onRetry={() => setRetryCount((prev) => prev + 1)}
             />
           </div>
         )}
@@ -197,18 +197,18 @@ export default function IssueRecommendations() {
           {issues.map((issue) => (
             <article
               key={issue.id}
-              className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl"
+              className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl dark:border-[#1f2a44] dark:bg-[#0f172a] dark:hover:shadow-cyan-900/20"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                  <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400 dark:text-gray-500">
                     Issue #{issue.id}
                   </p>
                   <a
                     href={issue.url}
                     target="_blank"
                     rel="noreferrer"
-                    className="mt-2 block text-lg font-semibold text-slate-900 hover:text-cyan-700"
+                    className="mt-2 block text-lg font-semibold text-slate-900 hover:text-cyan-700 dark:text-white dark:hover:text-cyan-400"
                   >
                     {issue.title}
                   </a>
@@ -222,23 +222,23 @@ export default function IssueRecommendations() {
                 </span>
               </div>
 
-              <p className="mt-3 line-clamp-3 text-sm leading-6 text-slate-600">
+              <p className="mt-3 line-clamp-3 text-sm leading-6 text-slate-600 dark:text-gray-400">
                 {issue.body}
               </p>
 
               <div className="mt-4 flex flex-wrap gap-2">
                 {issue.isGoodFirst && (
-                  <span className="rounded-full bg-cyan-100 px-3 py-1 text-xs font-semibold text-cyan-800">
+                  <span className="rounded-full bg-cyan-100 px-3 py-1 text-xs font-semibold text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300">
                     Good first issue
                   </span>
                 )}
                 {issue.historyMatch > 0 && (
-                  <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold text-violet-700">
+                  <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
                     Matches your recent work
                   </span>
                 )}
                 {issue.stackMatch > 0 && (
-                  <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                  <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
                     {issue.stackMatch} stack match
                     {issue.stackMatch > 1 ? 'es' : ''}
                   </span>
@@ -249,7 +249,7 @@ export default function IssueRecommendations() {
                 {issue.labels.map((label) => (
                   <span
                     key={label}
-                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
+                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-[#1a2332] dark:text-gray-300"
                   >
                     {label}
                   </span>

--- a/frontend/src/components/PageShell.jsx
+++ b/frontend/src/components/PageShell.jsx
@@ -1,0 +1,12 @@
+import Footer from './Footer';
+
+export default function PageShell({ children, className = '', withFooter = false }) {
+  return (
+    <div
+      className={`min-h-screen bg-gradient-to-br from-slate-100 via-white to-cyan-50 dark:from-gray-900 dark:via-[#0f172a] dark:to-[#0c4a6e] pt-24 pb-16 ${className}`}
+    >
+      {children}
+      {withFooter && <Footer />}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,18 @@ body {
   @apply bg-white dark:bg-[#0B0F1A] text-gray-900 dark:text-gray-100;
 }
 
+@layer components {
+  .page-card {
+    @apply rounded-3xl border border-slate-200 bg-white/80 shadow-xl backdrop-blur
+           dark:border-[#1f2a44] dark:bg-[#0f172a]/80;
+  }
+
+  .page-input {
+    @apply rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none
+           dark:border-[#1f2a44] dark:bg-[#0f172a] dark:text-white;
+  }
+}
+
 /* Screen-reader only utility (used for accessible labels) */
 .sr-only {
   position: absolute;

--- a/frontend/src/pages/Recommendations.jsx
+++ b/frontend/src/pages/Recommendations.jsx
@@ -1,12 +1,10 @@
+import PageShell from '../components/PageShell';
 import IssueRecommendations from '../components/IssueRecommendations';
-import Footer from '../components/Footer';
 
 export default function Recommendations() {
   return (
-  <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-cyan-50 dark:from-gray-900 dark:via-[#0f172a] dark:to-[#0c4a6e] pt-24 pb-16">
-    <IssueRecommendations />
-    <Footer />
-  </div>
-
+    <PageShell withFooter>
+      <IssueRecommendations />
+    </PageShell>
   );
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fix dark mode on the Recommendations page by removing the light-only overlay in `IssueRecommendations` and adding a reusable `PageShell` layout so themed pages stay consistent in both light and dark modes.

## Description
The Recommendations page navbar respected dark mode, but the main content stayed white because `IssueRecommendations.jsx` rendered its own full-screen light background and used light-only styles on cards, inputs, filters, and badges.

**Changes made:**
- **`frontend/src/components/PageShell.jsx`** — New reusable page wrapper with light/dark gradient background and optional footer
- **`frontend/src/pages/Recommendations.jsx`** — Uses `PageShell` instead of a duplicate inline wrapper
- **`frontend/src/components/IssueRecommendations.jsx`** — Removed light-only `min-h-screen` overlay; added `dark:` variants to header card, inputs, filter pills, issue cards, and badges; uses `.page-card` and `.page-input` utilities
- **`frontend/src/index.css`** — Added `.page-card` and `.page-input` semantic utilities for future pages

**Why:**
- Fixes inconsistent theming on `/recommendations` in dark mode
- Aligns the page visually with other themed pages like Contributors and Contact
- Gives new pages a standard layout pattern for built-in dark mode support

## Related Issue
Fixes #164 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated if required