### PR TITLE
fix: make login and signup pages fit within viewport

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -9,7 +9,13 @@ import { toast } from 'react-toastify';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { FcGoogle } from 'react-icons/fc';
-import { IoMail, IoLockClosed, IoEye, IoEyeOutline, IoArrowBack } from 'react-icons/io5';
+import {
+  IoMail,
+  IoLockClosed,
+  IoEye,
+  IoEyeOutline,
+  IoArrowBack,
+} from 'react-icons/io5';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -28,7 +34,7 @@ function Login() {
   const { getCurrentUser } = useContext(userDataContext);
   const { product } = useContext(shopDataContext);
   const navigate = useNavigate();
-  const [showEmailForm, setShowEmailForm] = useState(false);
+  const [showEmailForm, setShowEmailForm] = useState(true);
 
   const leftPanelRef = useRef(null);
   const googleBtnRef = useRef(null);
@@ -349,7 +355,7 @@ function Login() {
       </div>
 
       {/* RIGHT PANEL - Auth Form */}
-      <div className="w-full lg:w-1/2 flex items-center justify-center px-6 py-12 bg-white dark:bg-[#0B0F1A] relative">
+      <div className="w-full lg:w-1/2 flex items-center justify-center px-6 py-4 bg-white dark:bg-[#0B0F1A] relative">
         {/* Floating Back to Home Link */}
         <button
           onClick={() => navigate('/')}
@@ -357,14 +363,16 @@ function Login() {
           aria-label="Back to Home"
         >
           <IoArrowBack className="w-4 h-4 transition-transform group-hover:-translate-x-1 text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-400" />
-          <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">Back to Home</span>
+          <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">
+            Back to Home
+          </span>
         </button>
 
         <div className="login-container max-w-md w-full">
           {/* Mobile Logo */}
           <div
             onClick={() => navigate('/')}
-            className="cursor-pointer mb-8 text-center lg:hidden"
+            className="cursor-pointer mb-4 text-center lg:hidden"
             aria-label="Navigate Home"
           >
             <h1 className="text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-blue-500">
@@ -373,7 +381,7 @@ function Login() {
           </div>
 
           {/* Header */}
-          <div className="mb-8">
+          <div className="mb-4">
             <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
               Welcome Back!
             </h2>
@@ -383,13 +391,13 @@ function Login() {
           </div>
 
           {/* Card Container */}
-          <div className="space-y-6">
+          <div className="space-y-4">
             {/* LAYER 1: Google Login - Primary CTA with Staged Entry */}
             <button
               ref={googleBtnRef}
               onClick={googleLogin}
               disabled={googleLoading}
-              className="w-full flex items-center justify-center gap-3 bg-[#2563EB] hover:bg-[#1d4ed8] text-white rounded-xl py-4 px-6 font-semibold transition-all duration-300 hover:shadow-lg transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex items-center justify-center gap-3 bg-[#2563EB] hover:bg-[#1d4ed8] text-white rounded-xl py-3 px-6 font-semibold transition-all duration-300 hover:shadow-lg transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {googleLoading ? (
                 <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
@@ -409,7 +417,7 @@ function Login() {
               </button>
 
               {showEmailForm && (
-                <div className="mt-6 space-y-6 animate-fadeIn">
+                <div className="mt-4 space-y-4 animate-fadeIn">
                   {/* Divider */}
                   <div className="flex items-center">
                     <div className="flex-grow border-t border-gray-300 dark:border-gray-700"></div>
@@ -420,7 +428,7 @@ function Login() {
                   </div>
 
                   {/* Form */}
-                  <form onSubmit={handleLogin} className="space-y-5">
+                  <form onSubmit={handleLogin} className="space-y-4">
                     {/* Email Field */}
                     <div className="form-element">
                       <label className="block text-gray-700 dark:text-gray-300 text-sm font-medium mb-2">
@@ -511,7 +519,7 @@ function Login() {
             </div>
 
             {/* Sign Up Link */}
-            <div className="form-element text-center pt-6 border-t border-gray-200 dark:border-gray-700">
+            <div className="form-element text-center pt-4 border-t border-gray-200 dark:border-gray-700">
               <p className="text-gray-600 dark:text-gray-400">
                 Don't have an account?{' '}
                 <button

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -168,7 +168,7 @@ function Registration() {
   return (
     <>
       {step === '1' ? (
-        <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gradient-to-br dark:from-gray-900 dark:via-[#0f172a] dark:to-[#0c4a6e] px-4 py-8 transition-colors duration-300 relative">
+        <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gradient-to-br dark:from-gray-900 dark:via-[#0f172a] dark:to-[#0c4a6e] px-4 py-3 transition-colors duration-300 relative">
           {/* Floating Back to Home Link */}
           <button
             onClick={() => navigate('/')}
@@ -176,7 +176,9 @@ function Registration() {
             aria-label="Back to Home"
           >
             <IoArrowBack className="w-4 h-4 transition-transform group-hover:-translate-x-1 text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-400" />
-            <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">Back to Home</span>
+            <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">
+              Back to Home
+            </span>
           </button>
 
           {/* Animated Background Elements */}
@@ -187,10 +189,10 @@ function Registration() {
 
           <div className="registration-container max-w-md w-full relative z-10">
             {/* Header */}
-            <div className="text-center mb-8">
+            <div className="text-center mb-4">
               <div
                 onClick={() => navigate('/')}
-                className="cursor-pointer mb-6 inline-block"
+                className="cursor-pointer mb-3 inline-block"
                 aria-label="Navigate Home"
               >
                 <h1 className="text-5xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-blue-500">
@@ -207,12 +209,12 @@ function Registration() {
             </div>
 
             {/* Card Container */}
-            <div className="bg-white dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-8 shadow-2xl transition-colors duration-300">
+            <div className="bg-white dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 shadow-2xl transition-colors duration-300">
               {/* Google Signup Button */}
               <button
                 onClick={googleSignup}
                 disabled={googleLoading}
-                className="form-element w-full flex items-center justify-center gap-3 bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 border border-gray-300 dark:border-gray-600 rounded-xl py-3 px-4 text-gray-700 dark:text-white font-medium transition-all duration-300 hover:border-gray-400 dark:hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed mb-6"
+                className="form-element w-full flex items-center justify-center gap-3 bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 border border-gray-300 dark:border-gray-600 rounded-xl py-2.5 px-4 text-gray-700 dark:text-white font-medium transition-all duration-300 hover:border-gray-400 dark:hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed mb-4"
               >
                 {googleLoading ? (
                   <div className="w-5 h-5 border-2 border-gray-600 dark:border-white border-t-transparent rounded-full animate-spin"></div>
@@ -223,7 +225,7 @@ function Registration() {
               </button>
 
               {/* Divider */}
-              <div className="flex items-center mb-6">
+              <div className="flex items-center mb-4">
                 <div className="flex-grow border-t border-gray-300 dark:border-gray-600"></div>
                 <span className="mx-4 text-gray-500 dark:text-gray-400 text-sm">
                   OR
@@ -232,7 +234,7 @@ function Registration() {
               </div>
 
               {/* Form */}
-              <form onSubmit={handleSignup} className="space-y-5">
+              <form onSubmit={handleSignup} className="space-y-4">
                 {/* Name Field */}
                 <div className="form-element">
                   <label className="block text-gray-300 text-sm mb-2">
@@ -354,7 +356,7 @@ function Registration() {
               </form>
 
               {/* Login Link */}
-              <div className="form-element text-center mt-6 pt-6 border-t border-gray-700">
+              <div className="form-element text-center mt-4 pt-4 border-t border-gray-700">
                 <p className="text-gray-400">
                   Already have an account?{' '}
                   <button
@@ -364,28 +366,6 @@ function Registration() {
                     Sign In
                   </button>
                 </p>
-              </div>
-            </div>
-
-            {/* Security Badges */}
-            <div className="form-element mt-6 grid grid-cols-3 gap-4 text-center">
-              <div className="p-3 bg-gray-800/50 rounded-lg">
-                <div className="w-8 h-8 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-2">
-                  <span className="text-green-400 text-sm">🔒</span>
-                </div>
-                <p className="text-gray-400 text-xs">SSL Secure</p>
-              </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg">
-                <div className="w-8 h-8 bg-blue-500/20 rounded-full flex items-center justify-center mx-auto mb-2">
-                  <span className="text-blue-400 text-sm">🛡️</span>
-                </div>
-                <p className="text-gray-400 text-xs">Data Protected</p>
-              </div>
-              <div className="p-3 bg-gray-800/50 rounded-lg">
-                <div className="w-8 h-8 bg-cyan-500/20 rounded-full flex items-center justify-center mx-auto mb-2">
-                  <span className="text-cyan-400 text-sm">⚡</span>
-                </div>
-                <p className="text-gray-400 text-xs">Fast Signup</p>
               </div>
             </div>
           </div>
@@ -399,7 +379,9 @@ function Registration() {
             aria-label="Back to Home"
           >
             <IoArrowBack className="w-4 h-4 transition-transform group-hover:-translate-x-1 text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-400" />
-            <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">Back to Home</span>
+            <span className="group-hover:text-cyan-600 dark:group-hover:text-cyan-400">
+              Back to Home
+            </span>
           </button>
 
           <div className="max-w-md w-full bg-white dark:bg-gray-900 p-8 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
# Summary

Reduces excessive spacing on the Login and Signup pages so all essential form elements are visible within a single viewport height (100vh) on standard desktop resolutions without vertical scrolling.

# Description

Both auth pages had accumulated vertical padding and margins that pushed the total content height beyond 768px on common desktop screens (1366×768, 1440×900, 1920×1080).

## Login (Login.jsx)

* Show email/password form by default (`showEmailForm` initialized to `true`) so all form fields are visible on page load.
* Right panel: `py-12` → `py-4` (saves ~64px of dead space).
* Header margin: `mb-8` → `mb-4`.
* Card container gap: `space-y-6` → `space-y-4`.
* Google button: `py-4` → `py-3`.
* Expanded email form spacing: `mt-6 space-y-6` → `mt-4 space-y-4`.
* Form fields gap: `space-y-5` → `space-y-4`.
* Footer link: `pt-6` → `pt-4`.

## Signup (Registration.jsx)

* Outer wrapper: `py-8` → `py-3` (saves ~40px).
* Header: `mb-8` → `mb-4`, logo `mb-6` → `mb-3`.
* Card padding: `p-8` → `p-5`.
* Google button: `py-3 mb-6` → `py-2.5 mb-4`.
* Divider: `mb-6` → `mb-4`.
* Form gap: `space-y-5` → `space-y-4`.
* Login link: `mt-6 pt-6` → `mt-4 pt-4`.
* Removed the decorative 3-badge security row below the card (~120px saved — the single largest contributor to overflow).

All functional elements (logo, heading, Google button, form fields, terms checkbox, submit button, and sign-in/sign-up footer link) remain visible and unclipped. No layout structure, validation logic, animation, or theme was altered.

# Related Issue

Fixes #330


# Images
<img width="1536" height="747" alt="image" src="https://github.com/user-attachments/assets/d5a3a16c-2af2-4b5c-bc40-60b74a36652f" />

# Type of Change

* [x] Bug fix
* [x] UI/UX improvement

# Checklist

* [x] Code follows project guidelines
* [x] Tested locally
* [x] No console errors
* [x] Documentation updated if required
