### PR TITLE
fix: update footer social media links to open correct platforms

### DIFF
--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1081,30 +1081,35 @@ function LandingPage() {
                 shoppers. Discover, shop, and express yourself.
               </p>
               <div className="mt-4 flex items-center gap-3">
-                {[
-                  {
-                    Icon: FaInstagram,
-                    label: 'Instagram',
-                    color: 'hover:text-pink-500',
-                    shadow: 'hover:shadow-[0_0_20px_rgba(225,48,108,0.45)]',
-                  },
-                  {
-                    Icon: FaXTwitter,
-                    label: 'X',
-                    color: 'hover:text-slate-100',
-                    shadow: 'hover:shadow-[0_0_20px_rgba(255,255,255,0.25)]',
-                  },
-                  {
-                    Icon: FaFacebook,
-                    label: 'Facebook',
-                    color: 'hover:text-blue-500',
-                    shadow: 'hover:shadow-[0_0_20px_rgba(24,119,242,0.45)]',
-                  },
-                ].map(({ Icon, label, color, shadow }) => (
-                  <a
-                    key={label}
-                    href="#"
-                    aria-label={`Follow Riveto on ${label}`}
+               {[
+  {
+    Icon: FaInstagram,
+    label: 'Instagram',
+    url: 'https://www.instagram.com',
+    color: 'hover:text-pink-500',
+    shadow: 'hover:shadow-[0_0_20px_rgba(225,48,108,0.45)]',
+  },
+  {
+    Icon: FaXTwitter,
+    label: 'X',
+    url: 'https://www.x.com',
+    color: 'hover:text-slate-100',
+    shadow: 'hover:shadow-[0_0_20px_rgba(255,255,255,0.25)]',
+  },
+  {
+    Icon: FaFacebook,
+    label: 'Facebook',
+    url: 'https://www.facebook.com',
+    color: 'hover:text-blue-500',
+    shadow: 'hover:shadow-[0_0_20px_rgba(24,119,242,0.45)]',
+  },
+].map(({ Icon, label, url, color, shadow }) => (
+  <a
+    key={label}
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label={`Follow Riveto on ${label}`}
                     className={`w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-800 flex items-center justify-center text-gray-500 dark:text-gray-400 transition-all duration-400 hover:scale-125 ${color} ${shadow}`}
                   >
                     <Icon className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
# Pull Request

## Summary
The footer social media icons (Instagram, X/Twitter, Facebook) 
previously used href="#" which caused the page to scroll back 
to the top when clicked instead of navigating to the intended 
platform. This PR fixes that by adding proper URLs and opening 
them in a new tab.

## Description
The social media icons on the footer now directs us to the respective social media page and not thefront page of the website.
The following are the files that changed :
| `frontend/src/pages/LandingPage.jsx` | Added `url` field to each social icon object in the footer array, updated `href="#"` to `href={url}`, added `target="_blank"` and `rel="noopener noreferrer"` for security |

## Related Issue
Fixes #343 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated if required
