### PR TITLE
feat: add dark mode toggle to landing page navbar

### DIFF
--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,5 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ThemeContext } from '../context/ThemeContext';
+import { BsSun, BsMoon } from 'react-icons/bs';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   ShoppingBag,
@@ -286,6 +288,7 @@ function SectionHeader({ eyebrow, eyebrowColor, title, highlight, subtitle }) {
 // ─── Landing Page ─────────────────────────────────────────────────────────────
 
 function LandingPage() {
+  const { theme, toggleTheme } = useContext(ThemeContext);
   const navigate = useNavigate();
   const [scrolled, setScrolled] = useState(false);
 
@@ -351,9 +354,22 @@ function LandingPage() {
           </nav>
 
           <div className="flex items-center gap-2 sm:gap-3">
-            <button
-              type="button"
-              onClick={() => navigate('/login')}
+  {/* THEME TOGGLE */}
+  <button
+    type="button"
+    onClick={toggleTheme}
+    className="p-1.5 rounded-full hover:bg-white/10 transition-colors"
+    aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+  >
+    {theme === 'dark' ? (
+      <BsSun className="text-yellow-400 text-lg" />
+    ) : (
+      <BsMoon className="text-gray-700 text-lg" />
+    )}
+  </button>
+  <button
+    type="button"
+    onClick={() => navigate('/login')}
               className="text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-[#2563EB] dark:hover:text-blue-400 transition-colors px-3 py-2 hidden sm:block"
             >
               Login


### PR DESCRIPTION
# Pull Request

## Summary
The landing page navbar had no dark mode toggle, making it 
impossible for users to switch themes from the landing page.
This PR adds a sun/moon toggle button to the landing page .

## Description
This PR adds a sun/moon toggle button to the landing page 
navbar that connects to the existing ThemeContext, allowing 
users to switch between light and dark mode directly from 
the landing page.

the following file were changed
 | File | Change made |
|------|-------------|
| `frontend/src/pages/LandingPage.jsx` | Added `useContext` to React imports, imported `ThemeContext` and `BsSun`/`BsMoon` icons, connected `theme` and `toggleTheme` from ThemeContext, added toggle button to landing navbar |
## Related Issue
Fixes #344 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated if required
