### PR TITLE
feat:  Add Recently Viewed and Picks For You sections on Homepage

### DIFF
--- a/backend/controller/viewHistoryController.js
+++ b/backend/controller/viewHistoryController.js
@@ -1,0 +1,209 @@
+import mongoose from "mongoose";
+import ViewHistory from "../model/viewHistoryModel.js";
+import DismissedPick from "../model/dismissedPickModel.js";
+import Product from "../model/productModel.js";
+import User from "../model/userModel.js";
+import Order from "../model/orderModel.js";
+
+// Cap on how many view-history rows we keep per user.
+const MAX_HISTORY = 20;
+// How many products each "row" returns by default.
+const DEFAULT_LIMIT = 8;
+
+// ✅ Log a product view (called from the product detail page).
+// Debounced on the frontend so refreshing the same page doesn't spam entries;
+// here we also de-dupe at the DB level via upsert so re-viewing a product
+// just bumps its timestamp instead of creating a new row.
+export const logView = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { productId } = req.body;
+
+    if (!productId || !mongoose.Types.ObjectId.isValid(productId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Valid productId is required" });
+    }
+
+    await ViewHistory.findOneAndUpdate(
+      { userId, productId },
+      { viewedAt: new Date() },
+      { upsert: true, new: true }
+    );
+
+    // Trim history beyond MAX_HISTORY, keeping only the most recent entries.
+    const staleEntries = await ViewHistory.find({ userId })
+      .sort({ viewedAt: -1 })
+      .skip(MAX_HISTORY)
+      .select("_id");
+
+    if (staleEntries.length) {
+      await ViewHistory.deleteMany({
+        _id: { $in: staleEntries.map((entry) => entry._id) },
+      });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("❌ Error in logView:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// ✅ Get the logged-in user's recently viewed products, most recent first.
+export const getRecentlyViewed = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const limit = Math.min(
+      Math.max(Number(req.query.limit) || DEFAULT_LIMIT, 1),
+      MAX_HISTORY
+    );
+
+    const history = await ViewHistory.find({ userId })
+      .sort({ viewedAt: -1 })
+      .limit(limit)
+      .populate("productId");
+
+    // A viewed product may have been deleted/removed since — skip those.
+    const products = history
+      .filter((entry) => entry.productId)
+      .map((entry) => entry.productId);
+
+    return res.status(200).json({ success: true, products });
+  } catch (error) {
+    console.error("❌ Error in getRecentlyViewed:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// ✅ "Clear history" button on the homepage.
+export const clearViewHistory = async (req, res) => {
+  try {
+    await ViewHistory.deleteMany({ userId: req.userId });
+    return res
+      .status(200)
+      .json({ success: true, message: "Viewing history cleared" });
+  } catch (error) {
+    console.error("❌ Error in clearViewHistory:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// ✅ Remove a single product from Recently Viewed (the "✕" on each card).
+export const removeViewedItem = async (req, res) => {
+  try {
+    const { productId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(productId)) {
+      return res.status(400).json({ success: false, message: "Invalid productId" });
+    }
+
+    await ViewHistory.deleteOne({ userId: req.userId, productId });
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("❌ Error in removeViewedItem:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// ✅ Dismiss a single product from Picks For You (the "✕" on each card).
+// Picks are computed live, not stored, so "removing" one means remembering
+// not to recommend it again rather than deleting a row.
+export const dismissPick = async (req, res) => {
+  try {
+    const { productId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(productId)) {
+      return res.status(400).json({ success: false, message: "Invalid productId" });
+    }
+
+    await DismissedPick.findOneAndUpdate(
+      { userId: req.userId, productId },
+      { dismissedAt: new Date() },
+      { upsert: true }
+    );
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("❌ Error in dismissPick:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// ✅ Simple rule-based "Picks For You":
+// score categories using wishlist + cart only (no ML needed for v1),
+// exclude anything already purchased/wishlisted/in cart/dismissed, and fall
+// back to trending/best-seller items when there isn't enough signal yet.
+export const getPicksForYou = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const limit = Math.min(Math.max(Number(req.query.limit) || DEFAULT_LIMIT, 1), 20);
+
+    const user = await User.findById(userId).populate("wishlist");
+    if (!user) {
+      return res.status(404).json({ success: false, message: "User not found" });
+    }
+
+    const cartProductIds = Object.keys(user.cartData || {}).filter((id) =>
+      mongoose.Types.ObjectId.isValid(id)
+    );
+    const cartProducts = cartProductIds.length
+      ? await Product.find({ _id: { $in: cartProductIds } })
+      : [];
+
+    const orders = await Order.find({ userId: userId.toString() });
+    const dismissed = await DismissedPick.find({ userId }).select("productId");
+
+    // --- Build a category -> score map from wishlist + cart only ---
+    // (Recently viewed is intentionally excluded — it's a separate signal
+    // shown in its own "Recently Viewed" section, not a personalization input here.)
+    const categoryScore = {};
+    const bumpCategory = (category, weight) => {
+      if (!category) return;
+      categoryScore[category] = (categoryScore[category] || 0) + weight;
+    };
+
+    (user.wishlist || []).forEach((product) => bumpCategory(product?.category, 3));
+    cartProducts.forEach((product) => bumpCategory(product?.category, 3));
+
+    const topCategories = Object.entries(categoryScore)
+      .sort((a, b) => b[1] - a[1])
+      .map(([category]) => category);
+
+    // --- Exclusions: don't recommend what the user already has/bought/dismissed ---
+    const purchasedIds = orders.flatMap((order) =>
+      (order.items || []).map((item) => String(item._id))
+    );
+    const wishlistIds = (user.wishlist || []).map((product) => String(product._id));
+    const dismissedIds = dismissed.map((entry) => String(entry.productId));
+    const excludeIds = [
+      ...new Set([...purchasedIds, ...wishlistIds, ...cartProductIds, ...dismissedIds]),
+    ];
+
+    let picks = [];
+
+    if (topCategories.length) {
+      picks = await Product.find({
+        category: { $in: topCategories },
+        _id: { $nin: excludeIds },
+      })
+        .sort({ popularity: -1, rating: -1 })
+        .limit(limit);
+    }
+
+    // --- Fallback for new users / not enough personalized matches yet ---
+    if (picks.length < limit) {
+      const alreadyPicked = picks.map((product) => String(product._id));
+      const fallback = await Product.find({
+        _id: { $nin: [...excludeIds, ...alreadyPicked] },
+      })
+        .sort({ bestseller: -1, popularity: -1 })
+        .limit(limit - picks.length);
+
+      picks = [...picks, ...fallback];
+    }
+
+    return res.status(200).json({ success: true, products: picks });
+  } catch (error) {
+    console.error("❌ Error in getPicksForYou:", error);
+    return res.status(500).json({ success: false, message: "Server error" });
+  }
+};

--- a/backend/model/dismissedPickModel.js
+++ b/backend/model/dismissedPickModel.js
@@ -1,0 +1,29 @@
+import mongoose from "mongoose";
+
+// Tracks products a user has explicitly dismissed from "Picks For You" so we
+// don't keep recommending the same thing after they've said "not interested".
+const dismissedPickSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    productId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Product",
+      required: true,
+    },
+    dismissedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+dismissedPickSchema.index({ userId: 1, productId: 1 }, { unique: true });
+
+const DismissedPick = mongoose.model("DismissedPick", dismissedPickSchema);
+
+export default DismissedPick;

--- a/backend/model/viewHistoryModel.js
+++ b/backend/model/viewHistoryModel.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+const viewHistorySchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    productId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Product",
+      required: true,
+    },
+    viewedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+// One entry per (user, product) pair — re-viewing a product just bumps viewedAt
+// instead of creating duplicate rows.
+viewHistorySchema.index({ userId: 1, productId: 1 }, { unique: true });
+
+// Speeds up "most recently viewed products for this user" queries.
+viewHistorySchema.index({ userId: 1, viewedAt: -1 });
+
+const ViewHistory = mongoose.model("ViewHistory", viewHistorySchema);
+
+export default ViewHistory;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -12,11 +12,27 @@ import adminAuth from "../middleware/adminAuth.js";
 import { userRateLimiter, adminRateLimiter } from "../middleware/rateLimiters.js";
 import validateRequest from "../middleware/validateRequest.js";
 import { addressSchema } from "../validators/authSchemas.js";
+import {
+  logView,
+  getRecentlyViewed,
+  clearViewHistory,
+  removeViewedItem,
+  getPicksForYou,
+  dismissPick,
+} from "../controller/viewHistoryController.js";
 
 let userRoutes = express.Router();
 
 userRoutes.get("/getCurrentUser", isAuth, userRateLimiter, getCurrentUser);
 userRoutes.get("/getadmin", adminAuth, adminRateLimiter, getAdmin);
+
+// Recently Viewed + Picks For You — all protected by isAuth
+userRoutes.post("/recently-viewed", isAuth, userRateLimiter, logView);
+userRoutes.get("/recently-viewed", isAuth, userRateLimiter, getRecentlyViewed);
+userRoutes.delete("/recently-viewed", isAuth, userRateLimiter, clearViewHistory);
+userRoutes.delete("/recently-viewed/:productId", isAuth, userRateLimiter, removeViewedItem);
+userRoutes.get("/picks-for-you", isAuth, userRateLimiter, getPicksForYou);
+userRoutes.delete("/picks-for-you/:productId", isAuth, userRateLimiter, dismissPick);
 
 // Address routes — all protected by isAuth
 userRoutes.get("/address", isAuth, userRateLimiter, getAddresses);

--- a/frontend/src/components/PicksForYou.jsx
+++ b/frontend/src/components/PicksForYou.jsx
@@ -1,0 +1,132 @@
+import { useContext, useEffect, useState, useCallback } from 'react';
+import { FaMagic, FaTimes } from 'react-icons/fa';
+import apiConfig from '../utils/apiConfig';
+import { shopDataContext } from '../context/ShopContext';
+import { userDataContext } from '../context/UserContext';
+import Card from './Card';
+
+function PicksForYou() {
+  const { userData } = useContext(userDataContext);
+  const { compareList, toggleCompare } = useContext(shopDataContext);
+
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPicks = useCallback(async () => {
+    // Personalized picks require an account (wishlist/cart/view-history signals
+    // live on the user). Guests simply don't see this section yet.
+    if (!userData) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await apiConfig.get('/user/picks-for-you?limit=8', {
+        skipGlobalErrorToast: true,
+      });
+      if (res.data?.success) {
+        setItems(res.data.products || []);
+      }
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [userData]);
+
+  useEffect(() => {
+    fetchPicks();
+  }, [fetchPicks]);
+
+  // Dismiss a single pick via its "✕" button. Optimistic — removes it from
+  // the UI immediately, then tells the backend to stop recommending it.
+  const handleDismiss = async (productId) => {
+    setItems((prev) => prev.filter((item) => item._id !== productId));
+    try {
+      await apiConfig.delete(`/user/picks-for-you/${productId}`, {
+        skipGlobalErrorToast: true,
+      });
+    } catch {
+      // Non-critical — worst case it reappears next time picks refresh.
+    }
+  };
+
+  // Render only if there's actually something to show.
+  if (!loading && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="w-full py-10 sm:py-14 md:py-20 px-3 sm:px-4 md:px-8 relative overflow-hidden bg-white dark:bg-[#0B0F1A]">
+      <div className="max-w-7xl mx-auto relative z-10">
+        <div className="flex items-end justify-between mb-8 sm:mb-10">
+          <div>
+            <div className="inline-flex items-center gap-2 sm:gap-3 mb-2">
+              <div className="w-10 h-10 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center shadow-lg">
+                <FaMagic className="text-white text-lg" />
+              </div>
+              <h2
+                className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white"
+                style={{ fontFamily: 'Poppins, sans-serif' }}
+              >
+                Picks For You
+              </h2>
+            </div>
+            <p
+              className="text-gray-600 dark:text-gray-400 text-sm md:text-base max-w-md"
+              style={{ fontFamily: 'Inter, sans-serif' }}
+            >
+              Based on what you&apos;ve viewed, saved, and loved
+            </p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex gap-4 overflow-x-hidden pb-4">
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                className="flex-shrink-0 w-64 sm:w-72 h-80 rounded-2xl bg-gray-100 dark:bg-[#121826] animate-pulse"
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className="flex gap-4 overflow-x-auto snap-x snap-mandatory scroll-smooth pb-4 scrollbar-hide"
+            style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+          >
+            {items.map((item) => (
+              <div
+                key={item._id}
+                className="relative flex-shrink-0 w-64 sm:w-72 snap-start"
+              >
+                <button
+                  type="button"
+                  onClick={() => handleDismiss(item._id)}
+                  className="absolute -top-2 -right-2 z-20 w-7 h-7 rounded-full bg-gray-900/90 dark:bg-gray-700 text-white flex items-center justify-center shadow-lg hover:bg-red-500 transition-colors duration-200"
+                  aria-label={`Remove ${item.name} from picks for you`}
+                >
+                  <FaTimes className="text-xs" />
+                </button>
+                <Card
+                  name={item.name}
+                  id={item._id}
+                  price={item.price}
+                  image={item.image1}
+                  badge="PICK"
+                  badgeColor="from-purple-500 to-pink-500"
+                  onCompare={() => toggleCompare(item)}
+                  isCompared={compareList?.some((p) => p._id === item._id)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default PicksForYou;

--- a/frontend/src/components/RecentlyViewed.jsx
+++ b/frontend/src/components/RecentlyViewed.jsx
@@ -1,0 +1,168 @@
+import { useContext, useEffect, useState, useCallback } from 'react';
+import { FaHistory, FaTrash, FaTimes } from 'react-icons/fa';
+import { toast } from 'react-toastify';
+import apiConfig from '../utils/apiConfig';
+import { shopDataContext } from '../context/ShopContext';
+import { userDataContext } from '../context/UserContext';
+import {
+  getGuestViewedIds,
+  removeGuestViewedId,
+  clearGuestViewHistory,
+} from '../utils/guestViewHistory';
+import Card from './Card';
+
+function RecentlyViewed() {
+  const { userData } = useContext(userDataContext);
+  const { product, compareList, toggleCompare } = useContext(shopDataContext);
+
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchRecentlyViewed = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (userData) {
+        const res = await apiConfig.get('/user/recently-viewed?limit=8', {
+          skipGlobalErrorToast: true,
+        });
+        if (res.data?.success) {
+          setItems(res.data.products || []);
+        }
+      } else {
+        // Guests: hydrate locally-stored product ids against the already-loaded
+        // product catalog so the section can render before sign-in.
+        const ids = getGuestViewedIds();
+        const matched = ids
+          .map((id) => (product || []).find((p) => p._id === id))
+          .filter(Boolean);
+        setItems(matched);
+      }
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [userData, product]);
+
+  useEffect(() => {
+    fetchRecentlyViewed();
+  }, [fetchRecentlyViewed]);
+
+  const handleClearHistory = async () => {
+    try {
+      if (userData) {
+        await apiConfig.delete('/user/recently-viewed');
+      } else {
+        clearGuestViewHistory();
+      }
+      setItems([]);
+      toast.info('Viewing history cleared');
+    } catch {
+      // Error toast is already handled by the apiConfig interceptor.
+    }
+  };
+
+  // Dismiss a single card via its "✕" button. Optimistic — removes it from
+  // the UI immediately, then syncs the removal in the background.
+  const handleRemoveOne = async (productId) => {
+    setItems((prev) => prev.filter((item) => item._id !== productId));
+    try {
+      if (userData) {
+        await apiConfig.delete(`/user/recently-viewed/${productId}`, {
+          skipGlobalErrorToast: true,
+        });
+      } else {
+        removeGuestViewedId(productId);
+      }
+    } catch {
+      // Non-critical — worst case it reappears next time the list refreshes.
+    }
+  };
+
+  // Hide the whole section for first-time visitors with no history yet.
+  if (!loading && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="w-full py-10 sm:py-14 md:py-20 px-3 sm:px-4 md:px-8 relative overflow-hidden bg-white dark:bg-[#0B0F1A]">
+      <div className="max-w-7xl mx-auto relative z-10">
+        <div className="flex items-end justify-between mb-8 sm:mb-10">
+          <div>
+            <div className="inline-flex items-center gap-2 sm:gap-3 mb-2">
+              <div className="w-10 h-10 bg-[#2563EB] rounded-full flex items-center justify-center shadow-lg">
+                <FaHistory className="text-white text-lg" />
+              </div>
+              <h2
+                className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white"
+                style={{ fontFamily: 'Poppins, sans-serif' }}
+              >
+                Recently Viewed
+              </h2>
+            </div>
+            <p
+              className="text-gray-600 dark:text-gray-400 text-sm md:text-base max-w-md"
+              style={{ fontFamily: 'Inter, sans-serif' }}
+            >
+              Pick up where you left off
+            </p>
+          </div>
+
+          {items.length > 0 && (
+            <button
+              type="button"
+              onClick={handleClearHistory}
+              className="group flex items-center gap-2 text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400 font-semibold text-sm md:text-base transition-colors"
+              style={{ fontFamily: 'Inter, sans-serif' }}
+            >
+              <FaTrash className="text-xs group-hover:scale-110 transition-transform duration-200" />
+              Clear history
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="flex gap-4 overflow-x-hidden pb-4">
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                className="flex-shrink-0 w-64 sm:w-72 h-80 rounded-2xl bg-gray-100 dark:bg-[#121826] animate-pulse"
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className="flex gap-4 overflow-x-auto snap-x snap-mandatory scroll-smooth pb-4 scrollbar-hide"
+            style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+          >
+            {items.map((item) => (
+              <div
+                key={item._id}
+                className="relative flex-shrink-0 w-64 sm:w-72 snap-start"
+              >
+                <button
+                  type="button"
+                  onClick={() => handleRemoveOne(item._id)}
+                  className="absolute -top-2 -right-2 z-20 w-7 h-7 rounded-full bg-gray-900/90 dark:bg-gray-700 text-white flex items-center justify-center shadow-lg hover:bg-red-500 transition-colors duration-200"
+                  aria-label={`Remove ${item.name} from recently viewed`}
+                >
+                  <FaTimes className="text-xs" />
+                </button>
+                <Card
+                  name={item.name}
+                  id={item._id}
+                  price={item.price}
+                  image={item.image1}
+                  onCompare={() => toggleCompare(item)}
+                  isCompared={compareList?.some((p) => p._id === item._id)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default RecentlyViewed;

--- a/frontend/src/pages/Product.jsx
+++ b/frontend/src/pages/Product.jsx
@@ -1,11 +1,14 @@
-
 import LastestCollection from '../components/LastestCollection';
 import BestSeller from '../components/BestSeller';
+import RecentlyViewed from '../components/RecentlyViewed';
+import PicksForYou from '../components/PicksForYou';
 function Product() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-sky-50 dark:from-gray-900 dark:via-[#0f172a] dark:to-[#0c4a6e] pt-24 pb-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="space-y-16">
+          <RecentlyViewed />
+          <PicksForYou />
           <LastestCollection />
           <BestSeller />
         </div>

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -7,7 +7,7 @@ import apiConfig from '../utils/apiConfig';
 import 'react-toastify/dist/ReactToastify.css';
 import { FaChevronLeft, FaChevronRight, FaHeart, FaShare, FaShoppingCart, FaStar } from 'react-icons/fa';
 import RelatedProduct from '../components/RelatedProduct';
-
+import { recordGuestView } from '../utils/guestViewHistory';
 
 function ProductDetail() {
   const { userData } = useContext(userDataContext);
@@ -108,6 +108,26 @@ function ProductDetail() {
 
     fetchReviews();
   }, [productId, product, fetchReviews]);
+
+  // Log a "viewed" event for Recently Viewed / Picks For You. Debounced so a
+  // quick refresh or back-and-forth navigation doesn't spam duplicate entries.
+  useEffect(() => {
+    if (!productId) return;
+
+    const timer = setTimeout(() => {
+      if (userData) {
+        apiConfig
+          .post('/user/recently-viewed', { productId }, { skipGlobalErrorToast: true })
+          .catch(() => {
+            // Non-critical — failing to log a view shouldn't disrupt browsing.
+          });
+      } else {
+        recordGuestView(productId);
+      }
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [productId, userData]);
 
   const handleAddToCart = () => {
     if (!size) {

--- a/frontend/src/utils/guestViewHistory.js
+++ b/frontend/src/utils/guestViewHistory.js
@@ -1,0 +1,47 @@
+// Lightweight localStorage-backed view history for guests (logged-out users).
+// Logged-in users get real persistence via the backend (/user/recently-viewed);
+// this is just so the section isn't empty before sign-in.
+
+const STORAGE_KEY = 'riveto_guest_recently_viewed';
+const MAX_GUEST_HISTORY = 8;
+
+export function getGuestViewedIds() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const ids = raw ? JSON.parse(raw) : [];
+    return Array.isArray(ids) ? ids : [];
+  } catch {
+    return [];
+  }
+}
+
+export function recordGuestView(productId) {
+  if (!productId) return;
+  try {
+    const ids = getGuestViewedIds().filter((id) => id !== productId);
+    ids.unshift(productId);
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(ids.slice(0, MAX_GUEST_HISTORY))
+    );
+  } catch {
+    // localStorage may be unavailable (privacy mode, quota, etc.) — fail silently.
+  }
+}
+
+export function removeGuestViewedId(productId) {
+  try {
+    const ids = getGuestViewedIds().filter((id) => id !== productId);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearGuestViewHistory() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds "Recently Viewed" and "Picks For You" personalized sections to the homepage, with per-item dismiss controls.

## Description
This PR introduces two new homepage sections:

- **Recently Viewed** : shows the user's last few viewed products. Persisted via backend for logged-in users, with a localStorage fallback for guests. Includes a "Clear history" button and a per-card ✕ to remove a single item.
- **Picks For You** : rule-based product recommendations scored from the user's wishlist and cart categories. Excludes products already purchased, wishlisted, in cart, or previously dismissed, and falls back to trending/bestseller items for users with no signal yet. Includes a per-card ✕ to dismiss a single pick.

Sections are placed on the homepage in this order: **Recently Viewed → Picks For You → Trending Right Now → Best Sellers** (existing Trending/Best Sellers sections are untouched, just repositioned below the new ones).

**Backend changes:**
- `backend/model/viewHistoryModel.js` : new model tracking per-user product views
- `backend/model/dismissedPickModel.js` : new model tracking products dismissed from Picks For You
- `backend/controller/viewHistoryController.js` : new controller: `logView`, `getRecentlyViewed`, `clearViewHistory`, `removeViewedItem`, `getPicksForYou`, `dismissPick`
- `backend/routes/userRoutes.js` — new routes, all protected by existing `isAuth` + `userRateLimiter`:
  - `POST /api/user/recently-viewed`
  - `GET /api/user/recently-viewed`
  - `DELETE /api/user/recently-viewed` (clear all)
  - `DELETE /api/user/recently-viewed/:productId` (remove one)
  - `GET /api/user/picks-for-you`
  - `DELETE /api/user/picks-for-you/:productId` (dismiss one)

**Frontend changes:**
- `frontend/src/components/RecentlyViewed.jsx` — new homepage section component
- `frontend/src/components/PicksForYou.jsx` — new homepage section component
- `frontend/src/utils/guestViewHistory.js` — localStorage helper for guest view history
- `frontend/src/pages/Product.jsx` — wires the two new sections into the homepage composition
- `frontend/src/pages/ProductDetail.jsx` — logs a debounced "viewed" event when a product detail page is opened

<img width="1918" height="952" alt="Screenshot 2026-06-29 000223" src="https://github.com/user-attachments/assets/af3e9fcd-3ee8-468b-a211-825fca17217c" />

<img width="1918" height="956" alt="Screenshot 2026-06-29 000417" src="https://github.com/user-attachments/assets/ee446da8-2495-43d0-8e8a-298107be04cd" />

## Related Issue
Fixes #368

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required