### PR TITLE
feat: allow users to delete their own reviews

### DIFF
--- a/backend/controller/reviewController.js
+++ b/backend/controller/reviewController.js
@@ -116,3 +116,43 @@ export const getProductReviews = async (req, res) => {
     res.status(500).json({ message: "Server error" });
   }
 };
+
+export const deleteReview = async (req, res) => {
+  try {
+    const { reviewId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(reviewId)) {
+      return res.status(400).json({ message: "Invalid review ID" });
+    }
+
+    const review = await Review.findById(reviewId);
+
+    if (!review) {
+      return res.status(404).json({ message: "Review not found" });
+    }
+
+    if (review.userId.toString() !== req.userId) {
+      return res.status(403).json({
+        message: "You are not authorized to delete this review",
+      });
+    }
+
+
+await review.deleteOne();
+
+const { avgRating, reviewCount } = await recalculateProductRating(
+  review.productId
+);
+
+return res.status(200).json({
+  message: "Review deleted successfully",
+  avgRating,
+  reviewCount,
+});
+
+
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/backend/routes/reviewRoute.js
+++ b/backend/routes/reviewRoute.js
@@ -2,18 +2,30 @@ import express from "express";
 import {
   addReview,
   getProductReviews,
+  deleteReview,
 } from "../controller/reviewController.js";
-
 import authUser from "../middleware/isAuth.js";
-
 import validateRequest from "../middleware/validateRequest.js";
 import { addReviewSchema } from "../validators/authSchemas.js";
 import { userRateLimiter } from "../middleware/rateLimiters.js";
 
 const reviewRouter = express.Router();
 
-reviewRouter.post("/add", authUser, userRateLimiter, validateRequest(addReviewSchema), addReview);
+reviewRouter.post(
+  "/add",
+  authUser,
+  userRateLimiter,
+  validateRequest(addReviewSchema),
+  addReview
+);
 
 reviewRouter.get("/:productId", getProductReviews);
+
+reviewRouter.delete(
+  "/:reviewId",
+  authUser,
+  userRateLimiter,
+  deleteReview
+);
 
 export default reviewRouter;

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -202,6 +202,30 @@ function ProductDetail() {
     setIsEditingReview(true);
   };
 
+  const handleDeleteReview = async () => {
+  if (!userReview) return;
+
+  const confirmed = window.confirm(
+    'Are you sure you want to delete your review?'
+  );
+
+  if (!confirmed) return;
+
+  try {
+    const response = await apiConfig.delete(`/review/${userReview._id}`);
+
+    toast.success(response.data.message);
+
+    setReviewComment('');
+    setReviewRating(5);
+    setIsEditingReview(false);
+
+    fetchReviews();
+  } catch {
+    // API errors are shown by the global interceptor.
+  }
+};
+
   const handleCancelEdit = () => {
     setReviewComment('');
     setReviewRating(5);
@@ -568,17 +592,28 @@ function ProductDetail() {
                 {userReview && !isEditingReview ? (
                   <div className="bg-slate-100 dark:bg-gray-800/50 p-6 rounded-xl border border-cyan-400/40">
                     <div className="flex items-center justify-between mb-4">
-                      <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
-                        Your Review
-                      </h3>
-                      <button
-                        type="button"
-                        onClick={handleEditReview}
-                        className="text-cyan-400 hover:text-cyan-300 text-sm font-medium"
-                      >
-                        Edit Review
-                      </button>
-                    </div>
+  <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+    Your Review
+  </h3>
+
+  <div className="flex items-center gap-3">
+    <button
+      type="button"
+      onClick={handleEditReview}
+      className="text-cyan-400 hover:text-cyan-300 text-sm font-medium"
+    >
+      Edit Review
+    </button>
+
+    <button
+      type="button"
+      onClick={handleDeleteReview}
+      className="text-red-500 hover:text-red-400 text-sm font-medium"
+    >
+      Delete Review
+    </button>
+  </div>
+</div>
                     <div className="flex gap-1 mb-2" aria-hidden="true">
                       {[...Array(userReview.rating)].map((_, i) => (
                         <FaStar key={i} className="text-yellow-400" />


### PR DESCRIPTION
# Pull Request

## Summary
Adds support for users to delete their own product reviews through a secure backend endpoint and a frontend Delete Review action with confirmation.

## Description
This PR implements the review deletion feature requested in the issue.

### Backend
- Added authenticated `DELETE /api/review/:reviewId` endpoint.
- Ensured only the review owner can delete their review.
- Recalculated product rating and review count after deletion using the existing `recalculateProductRating` helper.

### Frontend
- Added a **Delete Review** button next to **Edit Review**.
- Added a confirmation step before deleting a review.
- Refreshed the review list after successful deletion.

## Related Issue
Fixes #382

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required