### PR TITLE
fix(order): standardize initial order status across admin and frontend

### DIFF
--- a/admin/src/pages/Order.jsx
+++ b/admin/src/pages/Order.jsx
@@ -54,7 +54,7 @@ function Order() {
   // Get unique status values for filter
   const statusOptions = [
     "All",
-    "Order Placed",
+    "Placed",
     "Packing",
     "Shipped",
     "Out for delivery",
@@ -65,11 +65,17 @@ function Order() {
   const filteredOrders =
     filterStatus === "All"
       ? orders
-      : orders.filter((order) => order.status === filterStatus);
+      : orders.filter((order) => {
+          if (filterStatus === "Placed") {
+            return order.status === "Placed" || order.status === "Order Placed";
+          }
+          return order.status === filterStatus;
+        });
 
   // Status color mapping
   const statusColors = {
-    "Order Placed": "bg-blue-500",
+    Placed: "bg-blue-500",
+    "Order Placed": "bg-blue-500", // backward compatibility for legacy records
     Packing: "bg-amber-500",
     Shipped: "bg-indigo-500",
     "Out for delivery": "bg-purple-500",
@@ -263,7 +269,9 @@ function Order() {
                             statusColors[order.status] || "bg-slate-600"
                           } text-white`}
                         >
-                          {order.status}
+                          {order.status === "Order Placed"
+                            ? "Placed"
+                            : order.status}
                         </span>
                       </div>
 
@@ -272,11 +280,15 @@ function Order() {
                           Update Status
                         </label>
                         <select
-                          value={order.status}
+                          value={
+                            order.status === "Order Placed"
+                              ? "Placed"
+                              : order.status
+                          }
                           onChange={(e) => statusHandler(e, order._id)}
                           className="w-full bg-slate-700/40 border border-slate-600 rounded-lg px-4 py-2 text-lg focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent transition-all cursor-pointer"
                         >
-                          <option value="Order Placed">Order Placed</option>
+                          <option value="Placed">Placed</option>
                           <option value="Packing">Packing</option>
                           <option value="Shipped">Shipped</option>
                           <option value="Out for delivery">

--- a/frontend/src/pages/Order.jsx
+++ b/frontend/src/pages/Order.jsx
@@ -109,7 +109,7 @@ function Order() {
 
   const statusSteps = [
     {
-      name: 'Order Placed',
+      name: 'Placed',
       icon: FaShoppingBag,
       color: 'from-blue-500 to-cyan-500',
     },
@@ -343,7 +343,9 @@ function Order() {
                         <span
                           className={`font-medium ${getStatusColor(item.status)}`}
                         >
-                          {item.status || 'Processing'}
+                          {item.status === 'Order Placed'
+                            ? 'Placed'
+                            : item.status || 'Processing'}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-gray-400">


### PR DESCRIPTION
# Pull Request

## Summary

Standardize the initial order status across the admin and user frontends by using `Placed` consistently, while maintaining backward compatibility for existing `Order Placed` records.

## Description

This PR fixes the inconsistency between the backend and frontend regarding the initial order status.

The backend creates new orders with the status `Placed`, whereas parts of the admin dashboard and user order tracking expected `Order Placed`. This mismatch caused incorrect status display, filtering, badge rendering, and dropdown behavior.

### Changes Made

* Updated the admin dashboard to use `Placed` as the canonical initial order status.
* Standardized status filters, dropdown options, badge mappings, and displayed status values.
* Updated the user order tracking step from `Order Placed` to `Placed`.
* Added backward compatibility so existing `Order Placed` records continue to display and function correctly without requiring any database migration or backend API changes.

### Testing

* Verified changes locally.
* Confirmed the application builds successfully.
* Ran project linting with no errors.
* Verified backend tests pass.
* Confirmed that order status transitions (`Placed → Packing → Shipped → Out for delivery → Delivered`) continue to work as expected.

## Related Issue

Fixes #398

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] UI/UX improvement
* [ ] Refactoring

## Checklist

* [x] Code follows project guidelines
* [x] Tested locally
* [x] No console errors
