### PR TITLE
feat: add password strength indicator during registration

### DIFF
--- a/frontend/src/context/ShopContext.jsx
+++ b/frontend/src/context/ShopContext.jsx
@@ -218,7 +218,6 @@ function ShopContext({ children }) {
       await apiConfig.post('/cart/clear');
       toast.success('Cart cleared successfully');
     } catch (error) {
-      console.log('clearCartData frontend error:', error);
       toast.error(error.response?.data?.message || 'Failed to clear cart on server');
 
       // Fallback: reload cart if backend call failed to sync state

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -29,7 +29,7 @@ function Registration() {
     email: '',
     password: '',
   });
-  const [errors, setErrors] = useState({});
+  const [passwordStrength, setPasswordStrength] = useState("");
   const { getCurrentUser } = useContext(userDataContext);
   const navigate = useNavigate();
 
@@ -92,6 +92,9 @@ function Registration() {
       ...prev,
       [name]: value,
     }));
+    if (name === "password") {
+  setPasswordStrength(getPasswordStrength(value));
+}
     // Clear error when user starts typing
     if (errors[name]) {
       setErrors((prev) => ({
@@ -100,6 +103,19 @@ function Registration() {
       }));
     }
   };
+  const getPasswordStrength = (password) => {
+  if (password.length < 8) return "Weak";
+
+  let score = 0;
+
+  if (/[A-Z]/.test(password)) score++;
+  if (/[a-z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+
+  if (score <= 2) return "Medium";
+  return "Strong";
+};
 
   const handleSignup = async (e) => {
     e.preventDefault();
@@ -305,11 +321,19 @@ function Registration() {
                       )}
                     </button>
                   </div>
-                  {errors.password && (
-                    <p className="text-red-400 text-sm mt-1">
-                      {errors.password}
-                    </p>
-                  )}
+                  {formData.password && (
+                    <p
+                    className={`text-sm mt-1 font-medium ${
+                      passwordStrength === "Weak"
+                      ? "text-red-400"
+                      : passwordStrength === "Medium"
+                      ? "text-yellow-400"
+                      : "text-green-400"
+                    }`}
+                    >
+                      Password Strength: {passwordStrength}
+                      </p>
+                    )}
                 </div>
 
                 {/* Terms Agreement */}

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -29,6 +29,7 @@ function Registration() {
     email: '',
     password: '',
   });
+  const [errors, setErrors] = useState({});
   const [passwordStrength, setPasswordStrength] = useState("");
   const { getCurrentUser } = useContext(userDataContext);
   const navigate = useNavigate();
@@ -321,19 +322,25 @@ function Registration() {
                       )}
                     </button>
                   </div>
-                  {formData.password && (
-                    <p
-                    className={`text-sm mt-1 font-medium ${
-                      passwordStrength === "Weak"
-                      ? "text-red-400"
-                      : passwordStrength === "Medium"
-                      ? "text-yellow-400"
-                      : "text-green-400"
-                    }`}
-                    >
-                      Password Strength: {passwordStrength}
-                      </p>
-                    )}
+                  {errors.password && (
+  <p className="text-red-400 text-sm mt-1">
+    {errors.password}
+  </p>
+)}
+
+{formData.password && (
+  <p
+    className={`text-sm mt-1 font-medium ${
+      passwordStrength === "Weak"
+        ? "text-red-400"
+        : passwordStrength === "Medium"
+        ? "text-yellow-400"
+        : "text-green-400"
+    }`}
+  >
+    Password Strength: {passwordStrength}
+  </p>
+)}
                 </div>
 
                 {/* Terms Agreement */}


### PR DESCRIPTION
# Pull Request

## Summary
Add a real-time password strength indicator to the registration form.

## Description
This PR introduces a live password strength indicator that updates as users type their password during registration. The strength is evaluated based on password length and the presence of uppercase letters, lowercase letters, numbers, and special characters. Users receive immediate feedback with Weak, Medium, or Strong indicators, encouraging the creation of more secure passwords.

## Related Issue
Closes #385

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required