### PR TITLE
fix: show error message instead of blank screen when Firebase env var…

### DIFF
--- a/frontend/utils/Firebase.js
+++ b/frontend/utils/Firebase.js
@@ -15,9 +15,20 @@ const missingFirebaseEnv = requiredFirebaseEnv.filter(
 );
 
 if (missingFirebaseEnv.length > 0) {
-  throw new Error(
-    `Missing Firebase environment variables: ${missingFirebaseEnv.join(', ')}`
-  );
+  const message = `Configuration error: missing environment variables (${missingFirebaseEnv.join(
+    ', '
+  )}). The site owner needs to add these in the hosting dashboard.`;
+
+  // React hasn't mounted yet at this point, so we write directly to the DOM
+  // to avoid leaving the user with a silent blank white screen.
+  document.body.innerHTML = `
+    <div style="font-family: sans-serif; max-width: 480px; margin: 80px auto; padding: 24px; text-align: center; color: #333;">
+      <h2 style="color:#c0392b;">Something's misconfigured</h2>
+      <p>${message}</p>
+    </div>
+  `;
+
+  throw new Error(message);
 }
 
 const firebaseConfig = {


### PR DESCRIPTION
# Pull Request

## Summary
Show a visible error message instead of a blank white screen when required Firebase environment variables are missing.

## Description
Currently, if any `VITE_FIREBASE_*` environment variables are missing at build time, `frontend/utils/Firebase.js` throws an error before React ever mount, resulting in a completely blank white page with no feedback to the user or developer (only visible in the browser console).

This PR updates the error handling in `Firebase.js` so that, before throwing, it writes a short, styled error message directly to the DOM. This makes misconfiguration immediately visible on screen instead of silently blanking the page, which should make this kind of issue much faster to diagnose in the future.

Note: this does not fix any specific deployment that's currently missing env vars, that still needs to be corrected in the hosting dashboard (e.g., Render) by whoever manages it. This PR only improves the failure behavior in code.

## Related Issue
Fixes #393 

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required
