### PR TITLE
fix: prevent auth endpoints from exposing password and reset-token fields

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -4,7 +4,7 @@ const connectdb = async () => {
         await mongoose.connect(process.env.MONGODB_URL);
         console.log("DB connected");
     } catch (_error) {
-        console.log("DB connection error");
+        console.log("DB connection error", _error.message);
     }
 }
 

--- a/backend/controller/authcontroller.js
+++ b/backend/controller/authcontroller.js
@@ -101,6 +101,8 @@ export const verifyOTP = async (req, res) => {
       password: tempUser.password,
     });
 
+    user.password=undefined;
+
     await TempUser.deleteOne({ email });
 
     sendNotification({
@@ -175,7 +177,7 @@ export const login = async (req, res) => {
   try {
     const { email, password } = req.body;
 
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email }).select("+password");
     if (!user) return res.status(400).json({ message: "User not found" });
     if (!user.password) {
       return res.status(400).json({
@@ -223,9 +225,11 @@ export const login = async (req, res) => {
       action: "User logged in",
     });
 
+    user.password=undefined;
     return res.status(200).json(user);
   } catch (_error) {
     console.log("login error:", _error);
+    
     return res.status(500).json({ message: `login error: ${_error}` });
   }
 };
@@ -266,9 +270,11 @@ export const googleLogin = async (req, res) => {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
+    user.password=undefined;
     return res.status(200).json(user);
   } catch (_error) {
     console.log("google login error:", _error);
+    
     return res.status(500).json({ message: `google login error: ${_error}` });
   }
 };

--- a/backend/model/userModel.js
+++ b/backend/model/userModel.js
@@ -38,6 +38,7 @@ const userSchema = new mongoose.Schema(
       required: function () {
         return this.authProvider === "local";
       },
+      select: false,
     },
 
     cartData: {
@@ -57,8 +58,8 @@ const userSchema = new mongoose.Schema(
       default: [],
     },
 
-    resetPasswordToken: String,
-    resetPasswordExpire: Date,
+    resetPasswordToken: {type: String, select: false},
+    resetPasswordExpire: {type: Date, select: false},
   },
   {
     timestamps: true,


### PR DESCRIPTION
## Description

Fixes #406.

The authentication endpoints (`login`, `googleLogin`, and `verifyOTP`) were returning the full Mongoose `User` document in their responses. That included the hashed `password` and, when present, `resetPasswordToken` and `resetPasswordExpire`, which shouldn't be sent back to the client.

### What changed

**`backend/model/userModel.js`**

* Added `select: false` to the `password`, `resetPasswordToken`, and `resetPasswordExpire` fields so they're excluded from query results by default across the application.

**`backend/controller/authcontroller.js`**

* **`login()`**

  * Added `.select("+password")` when fetching the user so `bcrypt.compare()` still has access to the password hash.
  * Cleared `user.password` before sending the response.
* **`googleLogin()`**

  * Cleared `user.password` before returning the user. Google accounts don't normally have a password, but this keeps the response consistent across auth flows.
* **`verifyOTP()`**

  * Cleared `user.password` immediately after `User.create(...)` and before returning the response.

### Why both `select: false` and `user.password = undefined`?

`select: false` prevents these fields from being included in future queries by default, which helps avoid similar issues elsewhere in the application.

However, it doesn't affect documents that already exist in memory. In `verifyOTP()`, the object returned by `User.create()` still contains the password because it was just created. Likewise, `login()` explicitly includes the password with `.select("+password")` so it can be verified. In both cases, the password needs to be removed before the response is sent.

### Testing

Tested locally against a running backend connected to MongoDB Atlas.

*  `POST /api/auth/login` with valid credentials returns the user without the `password` field.
*  `POST /api/auth/login` with an invalid password still returns `400 Invalid credentials`, confirming authentication still works after adding `.select("+password")`.
*  `POST /api/auth/googlelogin` returns the user without the `password` field.
*  Reviewed `verifyOTP()` to ensure the password is cleared before the response is returned.

### Out of scope

While testing this change, I also came across a few unrelated issues that prevent the backend from starting locally:

* Missing imports for `notificationRouter` and `botRoute` in `backend/index.js`.
* A leftover block in `backend/index.js` referencing `fileURLToPath`, `path`, and `fs` without importing them.
* Missing `sentiment` dependency in `package.json`.

These are separate issues and will be addressed independently rather than being included in this PR.

## Checklist

* [x] Verified successful login no longer exposes the `password` field.
* [x] Verified invalid login still returns the expected authentication error.
* [x] Verified `googleLogin` no longer exposes the `password` field.
* [x] Confirmed the fix is applied in the correct place inside `verifyOTP()`.
* [ ] End-to-end testing of `verifyOTP()` is still pending because SMTP isn't configured in my local environment. This can be verified on an environment with email configured or using a seeded `TempUser`.
