### PR TITLE
[GSSoC26] fix: Correct admin Sidebar CSS class typo

### DIFF
--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -40,7 +40,7 @@ useEffect(() => {
 }, [location.pathname]);
 
   return (
-    <div className="w-20 md:w-64 min-h-screen bg-gradient-to-b ffrom-slate-900 via-blue-900 to-slate-900 border-r border-gray-200 py-16 fixed left-0 top-0 shadow-lg z-40 transition-all duration-300">
+    <div className="w-20 md:w-64 min-h-screen bg-gradient-to-b from-slate-900 via-blue-900 to-slate-900 border-r border-gray-200 py-16 fixed left-0 top-0 shadow-lg z-40 transition-all duration-300">
       <div className="flex flex-col gap-2 pt-8 px-4 text-base">
         {menuItems.map((item) => (
           <div


### PR DESCRIPTION
## Description\nThis PR fixes a CSS class typo in the admin Sidebar component.\n\n## Changes\n- Fixed from-slate-900 to rom-slate-900 in dmin/src/components/Sidebar.jsx\n\n## Motivation\n- The typo from-slate-900 is an invalid Tailwind CSS class\n- This prevented the gradient background from rendering correctly\n- The sidebar background was likely not displaying as intended\n\n## Testing\n- Run admin app locally and verify sidebar gradient background renders\n- Check browser devtools - no invalid class warnings\n\nCloses #442\n\n**GSSoC26** contribution