### PR TITLE
[GSSoC26] feat: Validate refresh token expiry before allowing token rotation

### DIFF
--- a/backend/controller/authcontroller.js
+++ b/backend/controller/authcontroller.js
@@ -142,6 +142,12 @@ export const refreshToken = async (req, res) => {
       return res.status(403).json({ message: "Invalid refresh token" });
     }
 
+    // Check if the stored refresh token has expired
+    if (storedToken.expiresAt && storedToken.expiresAt < new Date()) {
+      await RefreshToken.findByIdAndDelete(storedToken._id);
+      return res.status(403).json({ message: "Refresh token expired, please login again" });
+    }
+
     const newAccessToken = generateAccessToken(decoded.id);
     const newRefreshToken = generateRefreshToken(decoded.id);
 


### PR DESCRIPTION
## Description
This PR adds validation for refresh token expiry in the database before allowing token rotation.

## Changes
- Added check for storedToken.expiresAt in the refreshToken controller
- If the stored refresh token has expired, it is deleted from the database
- Returns a clear error message prompting user to login again

## Motivation
- The expiresAt field was being set on refresh tokens but never validated
- An expired refresh token in the database could still be used for rotation
- This adds an additional security layer by enforcing database-level expiry

## Testing
- Create a refresh token with past expiry date in database
- Attempt to use it for token refresh - should return 403 with expiry message
- Verify valid tokens still work correctly

Closes #447

**GSSoC26** contribution