### PR TITLE
[GSSoC26] feat: Add cache-control headers for product listing

### DIFF
--- a/backend/controller/productController.js
+++ b/backend/controller/productController.js
@@ -132,24 +132,31 @@ export const listProducts = async (req, res) => {
     const skip = (page - 1) * limit;
 
     const [products, total] = await Promise.all([
-  Product.find({}).sort({ _id: 1 }).skip(skip).limit(limit).lean(),
-  Product.countDocuments({}),
-]);
-const productsWithReviewCount = await Promise.all(
-  products.map(async (product) => {
-    const reviewCount = await Review.countDocuments({
-      productId: product._id,
+      Product.find({}).sort({ _id: 1 }).skip(skip).limit(limit).lean(),
+      Product.countDocuments({}),
+    ]);
+    const productsWithReviewCount = await Promise.all(
+      products.map(async (product) => {
+        const reviewCount = await Review.countDocuments({
+          productId: product._id,
+        });
+
+        return {
+          ...product,
+          reviewCount,
+        };
+      })
+    );
+
+    // Add cache control headers for public product listing
+    // Cache for 5 minutes, allow stale content while revalidating
+    res.set({
+      "Cache-Control": "public, max-age=300, stale-while-revalidate=60",
+      "Vary": "Accept-Encoding",
     });
 
-    return {
-      ...product,
-      reviewCount,
-    };
-  })
-);
-
     return res.status(200).json({
-      products : productsWithReviewCount,
+      products: productsWithReviewCount,
       pagination: {
         page,
         limit,


### PR DESCRIPTION
## Description
This PR adds cache-control headers to the product listing endpoint to improve performance through caching.

## Changes
- Added `Cache-Control: public, max-age=300, stale-while-revalidate=60` header
- Added `Vary: Accept-Encoding` header
- Products are relatively static data suitable for caching

## Motivation
- Product listing is frequently accessed but rarely changes
- Caching reduces database load and improves response times
- Stale-while-revalidate allows serving cached content while fetching fresh data

## Testing
- Request `/api/product/list` and verify Cache-Control header is present
- Verify response is cacheable by browsers and CDNs
- Verify stale content is served while fresh data is fetched

Closes #451

**GSSoC26** contribution