### PR TITLE
[GSSoC26] feat: Add MongoDB connection retry logic with exponential backoff

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,11 +1,55 @@
 import mongoose from "mongoose";
-const connectdb = async () => {
-    try {
-        await mongoose.connect(process.env.MONGODB_URL);
-        console.log("DB connected");
-    } catch (_error) {
-        console.log("DB connection error");
+
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const connectWithRetry = async (retries = 0) => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URL);
+    console.log("✅ MongoDB connected successfully");
+  } catch (error) {
+    if (retries >= MAX_RETRIES) {
+      console.error(`❌ MongoDB connection failed after ${MAX_RETRIES} retries`);
+      throw error;
     }
-}
+
+    const delay = Math.min(BASE_DELAY_MS * Math.pow(2, retries), MAX_DELAY_MS);
+    const jitter = Math.random() * 1000;
+    const totalDelay = delay + jitter;
+
+    console.warn(
+      `⚠️ MongoDB connection attempt ${retries + 1} failed: ${error.message}. ` +
+        `Retrying in ${Math.round(totalDelay)}ms... (attempt ${retries + 2}/${MAX_RETRIES})`
+    );
+
+    await sleep(totalDelay);
+    return connectWithRetry(retries + 1);
+  }
+};
+
+const connectdb = async () => {
+  mongoose.connection.on("connected", () => {
+    console.log("📡 MongoDB connection established");
+  });
+
+  mongoose.connection.on("error", (err) => {
+    console.error("🔴 MongoDB connection error:", err.message);
+  });
+
+  mongoose.connection.on("disconnected", () => {
+    console.warn("🔌 MongoDB disconnected");
+  });
+
+  process.on("SIGINT", async () => {
+    await mongoose.connection.close();
+    console.log("🛑 MongoDB connection closed due to app termination");
+    process.exit(0);
+  });
+
+  return connectWithRetry();
+};
 
 export default connectdb;


### PR DESCRIPTION
## Description
This PR adds robust MongoDB connection retry logic with exponential backoff.

## Changes
- Implemented retry logic with exponential backoff (max 5 retries)
- Added jitter to prevent thundering herd problem
- Added connection event listeners (connected, error, disconnected)
- Added graceful shutdown handler for SIGINT
- Log detailed connection status and retry attempts

## Motivation
- MongoDB connections can fail temporarily due to network issues
- Without retries, the app crashes or fails to start on transient failures
- Exponential backoff prevents overwhelming the database during recovery

## Testing
- Start app with MongoDB down - verify retries and eventual success when DB comes up
- Verify connection events are logged correctly
- Verify graceful shutdown on SIGINT

Closes #453

**GSSoC26** contribution