### PR TITLE
[GSSoC26] feat: Add consistent API error response format middleware

### DIFF
--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,13 +1,43 @@
+import { ApiError, errorResponse } from "../utils/apiError.js";
+
 const errorHandler = (err, req, res, next) => {
-  void next;
+  console.error(`❌ Error [${req.requestId || "unknown"}]:`, err);
 
-  console.error(err);
+  if (err.name === "ValidationError") {
+    const errors = Object.values(err.errors).map((e) => ({
+      field: e.path,
+      message: e.message,
+    }));
+    return errorResponse(res, ApiError.badRequest("Validation failed", errors));
+  }
 
-  return res.status(err.status || 500).json({
-    success: false,
-    message: err.message || "Internal Server Error",
-    errors: err.errors || [],
-  });
+  if (err.name === "CastError") {
+    return errorResponse(res, ApiError.badRequest("Invalid ID format"));
+  }
+
+  if (err.code === 11000) {
+    const field = Object.keys(err.keyValue)[0];
+    return errorResponse(
+      res,
+      ApiError.badRequest(`${field} already exists`, [
+        { field, message: `${field} must be unique` },
+      ])
+    );
+  }
+
+  if (err.name === "JsonWebTokenError") {
+    return errorResponse(res, ApiError.unauthorized("Invalid token"));
+  }
+
+  if (err.name === "TokenExpiredError") {
+    return errorResponse(res, ApiError.unauthorized("Token expired"));
+  }
+
+  if (err instanceof ApiError) {
+    return errorResponse(res, err);
+  }
+
+  return errorResponse(res, ApiError.internal(err.message));
 };
 
 export default errorHandler;

--- a/backend/utils/apiError.js
+++ b/backend/utils/apiError.js
@@ -1,0 +1,54 @@
+export class ApiError extends Error {
+  constructor(statusCode, message, errors = [], isOperational = true) {
+    super(message);
+    this.statusCode = statusCode;
+    this.message = message;
+    this.errors = errors;
+    this.isOperational = isOperational;
+    this.timestamp = new Date().toISOString();
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  static badRequest(message, errors = []) {
+    return new ApiError(400, message, errors);
+  }
+
+  static unauthorized(message = "Unauthorized", errors = []) {
+    return new ApiError(401, message, errors);
+  }
+
+  static forbidden(message = "Forbidden", errors = []) {
+    return new ApiError(403, message, errors);
+  }
+
+  static notFound(message = "Resource not found", errors = []) {
+    return new ApiError(404, message, errors);
+  }
+
+  static internal(message = "Internal server error", errors = []) {
+    return new ApiError(500, message, errors, false);
+  }
+
+  static tooManyRequests(message = "Too many requests", errors = []) {
+    return new ApiError(429, message, errors);
+  }
+}
+
+export const errorResponse = (res, error) => {
+  const statusCode = error.statusCode || 500;
+  const message = error.message || "Internal server error";
+  const errors = error.errors || [];
+
+  return res.status(statusCode).json({
+    success: false,
+    message,
+    errors,
+    timestamp: error.timestamp || new Date().toISOString(),
+    ...(process.env.NODE_ENV !== "production" && { stack: error.stack }),
+  });
+};
+
+export const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};


### PR DESCRIPTION
## Description
This PR adds a consistent API error response format across all endpoints.

## Changes
- Created `backend/utils/apiError.js` with `ApiError` class and factory methods
- Updated `backend/middleware/errorHandler.js` to use consistent error format
- Standardized error responses: `{ success, message, errors, timestamp }`
- Added `asyncHandler` wrapper for automatic async error catching
- Include stack traces in development mode only
- Handle common error types: ValidationError, CastError, duplicate keys, JWT errors

## Motivation
- Error responses were inconsistent across different endpoints
- Some returned { success: false, message, errors }, others { message }, others { error }
- Consistent format improves frontend error handling and debugging

## Testing
- Trigger validation error and verify response format
- Trigger 404 and verify format
- Trigger JWT error and verify format
- Verify stack trace only appears in development

Closes #456

**GSSoC26** contribution