### PR TITLE
fix: hide internal env variable names from public error message

### DIFF
--- a/frontend/utils/Firebase.js
+++ b/frontend/utils/Firebase.js
@@ -15,7 +15,9 @@ const missingFirebaseEnv = requiredFirebaseEnv.filter(
 );
 
 if (missingFirebaseEnv.length > 0) {
-  const message = `Configuration error: missing environment variables (${missingFirebaseEnv.join(
+  // Keep the detailed message out of the DOM to avoid exposing
+  // internal environment variable names to end users.
+  const devMessage = `Configuration error: missing environment variables (${missingFirebaseEnv.join(
     ', '
   )}). The site owner needs to add these in the hosting dashboard.`;
 
@@ -23,12 +25,12 @@ if (missingFirebaseEnv.length > 0) {
   // to avoid leaving the user with a silent blank white screen.
   document.body.innerHTML = `
     <div style="font-family: sans-serif; max-width: 480px; margin: 80px auto; padding: 24px; text-align: center; color: #333;">
-      <h2 style="color:#c0392b;">Something's misconfigured</h2>
-      <p>${message}</p>
+      <h2 style="color:#c0392b;">We're currently unavailable</h2>
+      <p>This application is temporarily unavailable due to a configuration issue. Please try again later or contact support.</p>
     </div>
   `;
 
-  throw new Error(message);
+  throw new Error(devMessage);
 }
 
 const firebaseConfig = {


### PR DESCRIPTION
## Summary
Fixed a security issue where internal Firebase environment variable names were being exposed publicly in the error page shown to all visitors when the app is misconfigured.

## Description
Modified `frontend/utils/Firebase.js` to separate the detailed developer-facing error message from the user-facing DOM message. The internal environment variable names (`VITE_FIREBASE_AUTHDOMAIN`, `VITE_FIREBASE_PROJECTID`, etc.) are now only included in the thrown `Error` object (visible only in browser DevTools) and no longer rendered in the public-facing HTML.

**What changed:**
- Renamed `message` to `devMessage` to clarify its developer-only purpose
- The DOM now shows a generic, user-friendly message instead of exposing internal config details
- The detailed `devMessage` is only passed to `throw new Error()` so it appears in DevTools for developers, not in the public HTML

**Why:**
The live site was publicly exposing internal Firebase environment variable names to all visitors, which is a security concern — making it easier for bad actors to understand the app's infrastructure.

## Related Issue
Fixes #480

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required

## UI Evidence

**Before:**
<img width="1710" height="960" alt="Screenshot 2026-07-28 at 2 06 13 PM" src="https://github.com/user-attachments/assets/aafc80e9-a18f-4126-a4d8-ce64cefc90cc" />

**After:**
<img width="1710" height="960" alt="Screenshot 2026-07-28 at 2 03 55 PM" src="https://github.com/user-attachments/assets/710b745c-1f58-41e0-9c6a-9e1f323e5a25" />
