### PR TITLE
fix: make ScrollProgressBar track visible in dark mode using Tailwind…

### DIFF
--- a/frontend/src/components/ScrollProgressBar.jsx
+++ b/frontend/src/components/ScrollProgressBar.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import "../styles/ScrollProgressBar.css";
 
 const ScrollProgressBar = () => {
   const [progress, setProgress] = useState(0);
@@ -23,22 +22,10 @@ const ScrollProgressBar = () => {
   }, []);
 
   return (
-    <div style={{
-      position: "fixed",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "4px",
-      background: "rgba(0,0,0,0.08)",
-      zIndex: 9999,
-    }}>
-      <div style={{
-        height: "100%",
-        width: `${progress}%`,
-        transition: "width 0.08s linear",
-        borderRadius: "0 2px 2px 0",
-      }}
-      className="progress-fill"
+    <div className="fixed top-0 left-0 w-full h-1 bg-black/10 dark:bg-white/10 z-[9999]">
+      <div
+        style={{ width: `${progress}%`, transition: "width 0.08s linear" }}
+        className="h-full rounded-r-sm bg-gradient-to-r from-blue-500 to-purple-500"
       />
     </div>
   );

--- a/frontend/src/styles/ScrollProgressBar.css
+++ b/frontend/src/styles/ScrollProgressBar.css
@@ -1,4 +1,0 @@
-.progress-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #3b82f6, #8b5cf6);
-}


### PR DESCRIPTION
## Summary
Fixed the ScrollProgressBar component where the track background was invisible in dark mode due to hardcoded inline styles. Migrated all styles to Tailwind CSS classes for proper dark/light mode support.

## Description
**What changed:**
- Removed hardcoded inline `background: rgba(0,0,0,0.08)` on the track — invisible on dark backgrounds
- Replaced with Tailwind classes `bg-black/10 dark:bg-white/10` — visible in both light and dark mode
- Replaced all other inline styles with Tailwind utility classes
- Removed the now-unused `ScrollProgressBar.css` import and deleted the file
- Fill color migrated from CSS file to Tailwind gradient `bg-gradient-to-r from-blue-500 to-purple-500`

**Why:**
The track background was completely invisible in dark mode (the default theme), making the progress bar look broken for all dark mode users.

## Related Issue
Fixes #482

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Refactoring

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [ ] Documentation updated if required

## UI Evidence

**Before:**
Track background invisible in dark mode — only the fill portion was visible when scrolling.

**After:**
Track background now clearly visible in both light (`bg-black/10`) and dark (`bg-white/10`) modes. The progress fill uses Tailwind gradient classes matching the app's design.