### PR TITLE
feat: integrate GitHub OAuth and optimize recommendations portal

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,3 +55,11 @@ RATE_LIMIT_OTP_MAX=5
 RATE_LIMIT_BOT_MAX=30
 RATE_LIMIT_USER_MAX=200
 RATE_LIMIT_ADMIN_MAX=100
+
+# ===========================================
+# GitHub OAuth Configuration
+# ===========================================
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_CALLBACK_URL=http://localhost:3000/api/auth/github/callback
+FRONTEND_URL=http://localhost:5173

--- a/backend/model/userModel.js
+++ b/backend/model/userModel.js
@@ -59,6 +59,7 @@ const userSchema = new mongoose.Schema(
 
     resetPasswordToken: String,
     resetPasswordExpire: Date,
+    githubAccessToken: { type: String, select: false },
   },
   {
     timestamps: true,

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -13,8 +13,152 @@ import {
 import validateRequest from "../middleware/validateRequest.js";
 import { registerSchema, loginSchema } from "../validators/authSchemas.js";
 import { authIpLimiter, otpIpLimiter } from "../middleware/rateLimiters.js";
+import protect from "../middleware/isAuth.js";
+import { encrypt, decrypt } from "../utils/crypto.js";
+import axios from "axios";
+import jwt from "jsonwebtoken";
+import User from "../model/userModel.js";
+import RefreshToken from "../model/RefreshToken.js";
+import bcrypt from "bcryptjs";
 
 const authRoutes = express.Router();
+
+authRoutes.get("/github", (req, res) => {
+  const { token } = req.cookies;
+  if (!token) {
+    return res.status(401).json({ message: "Unauthorized: Please log in first to connect GitHub" });
+  }
+  try {
+    jwt.verify(token, process.env.JWT_SECRET);
+    const clientId = process.env.GITHUB_CLIENT_ID;
+    const redirectUri = process.env.GITHUB_CALLBACK_URL;
+    const scope = "repo,read:user";
+    const githubUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${scope}&state=${token}`;
+    return res.redirect(githubUrl);
+  } catch (_err) {
+    return res.status(401).json({ message: "Invalid or expired token" });
+  }
+});
+
+authRoutes.get("/github/callback", async (req, res) => {
+  const { code, state } = req.query;
+  if (!code) {
+    return res.status(400).json({ message: "Authorization code missing" });
+  }
+
+  try {
+    let userId;
+    try {
+      const decoded = jwt.verify(state, process.env.JWT_SECRET);
+      userId = decoded.userId;
+    } catch (_err) {
+      return res.status(401).json({ message: "Invalid OAuth state / session expired" });
+    }
+
+    const tokenResponse = await axios.post(
+      "https://github.com/login/oauth/access_token",
+      {
+        client_id: process.env.GITHUB_CLIENT_ID,
+        client_secret: process.env.GITHUB_CLIENT_SECRET,
+        code,
+        redirect_uri: process.env.GITHUB_CALLBACK_URL,
+      },
+      {
+        headers: {
+          Accept: "application/json",
+        },
+      }
+    );
+
+    const { access_token } = tokenResponse.data;
+    if (!access_token) {
+      return res.status(400).json({ message: "Failed to retrieve access token from GitHub" });
+    }
+
+    await axios.get("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+        "User-Agent": "RIVETO-App",
+      },
+    });
+
+    const encryptedToken = encrypt(access_token);
+    const user = await User.findByIdAndUpdate(
+      userId,
+      { githubAccessToken: encryptedToken },
+      { new: true }
+    );
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const newAccessToken = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, { expiresIn: "15m" });
+    const newRefreshToken = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, { expiresIn: "7d" });
+
+    await RefreshToken.findOneAndUpdate(
+      { userId: user._id },
+      {
+        tokenHash: await bcrypt.hash(newRefreshToken, 10),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+      { upsert: true }
+    );
+
+    res.cookie("token", newAccessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+      maxAge: 15 * 60 * 1000,
+    });
+
+    res.cookie("refreshToken", newRefreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+    return res.redirect(`${frontendUrl.replace(/\/+$/, "")}/recommendations`);
+  } catch (error) {
+    console.error("GitHub OAuth Callback error:", error);
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+    return res.redirect(`${frontendUrl.replace(/\/+$/, "")}/recommendations?error=oauth_failed`);
+  }
+});
+
+authRoutes.get("/github/profile", protect, async (req, res) => {
+  try {
+    const user = await User.findById(req.userId).select("+githubAccessToken");
+    if (!user || !user.githubAccessToken) {
+      return res.json({ connected: false });
+    }
+
+    const decryptedToken = decrypt(user.githubAccessToken);
+    if (!decryptedToken) {
+      return res.json({ connected: false });
+    }
+
+    const profileResponse = await axios.get("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${decryptedToken}`,
+        "User-Agent": "RIVETO-App",
+      },
+    });
+
+    const { avatar_url, login, public_repos } = profileResponse.data;
+    return res.json({
+      connected: true,
+      avatar_url,
+      login,
+      public_repos,
+    });
+  } catch (error) {
+    console.error("Failed to fetch GitHub profile:", error.message);
+    return res.status(500).json({ error: "Failed to fetch GitHub profile" });
+  }
+});
 
 authRoutes.post("/send-otp", otpIpLimiter, validateRequest(registerSchema), sendOTP);
 authRoutes.post("/verify-otp", otpIpLimiter, verifyOTP);
@@ -42,17 +186,24 @@ authRoutes.post("/verify-otp", otpIpLimiter, verifyOTP);
  *     responses:
  *       200:
  *         description: Login successful
+ *         headers:
+ *           Set-Cookie:
+ *             description: Contains httpOnly 'token' and 'refreshToken' cookies
+ *             schema:
+ *               type: string
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 token:
+ *                 _id:
  *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
- *                 refreshToken:
+ *                 name:
  *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
+ *                 email:
+ *                   type: string
+ *                 authProvider:
+ *                   type: string
  */
 authRoutes.post("/login", authIpLimiter, validateRequest(loginSchema), login);
 
@@ -66,7 +217,7 @@ authRoutes.post("/login", authIpLimiter, validateRequest(loginSchema), login);
  *       200:
  *         description: Successfully logged out
  */
-authRoutes.post("/logout",  logOut);
+authRoutes.post("/logout", protect, logOut);
 
 /**
  * @swagger
@@ -77,17 +228,24 @@ authRoutes.post("/logout",  logOut);
  *     responses:
  *       200:
  *         description: Login successful
+ *         headers:
+ *           Set-Cookie:
+ *             description: Contains httpOnly 'token' and 'refreshToken' cookies
+ *             schema:
+ *               type: string
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 token:
+ *                 _id:
  *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
- *                 refreshToken:
+ *                 name:
  *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
+ *                 email:
+ *                   type: string
+ *                 authProvider:
+ *                   type: string
  */
 authRoutes.post("/googlelogin", authIpLimiter, googleLogin);
 
@@ -100,17 +258,19 @@ authRoutes.post("/googlelogin", authIpLimiter, googleLogin);
  *     responses:
  *       200:
  *         description: Admin login successful
+ *         headers:
+ *           Set-Cookie:
+ *             description: Contains httpOnly 'adminToken' and 'adminRefreshToken' cookies
+ *             schema:
+ *               type: string
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 token:
+ *                 message:
  *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
- *                 refreshToken:
- *                   type: string
- *                   example: "eyJhbGciOiJIUzI1Ni..."
+ *                   example: "Admin logged in successfully"
  */
 authRoutes.post("/adminlogin", authIpLimiter, adminLogin);
 

--- a/backend/routes/recommendations.js
+++ b/backend/routes/recommendations.js
@@ -1,5 +1,8 @@
 import express from "express";
 import { getRecommendations } from "../services/recommendationService.js";
+import jwt from "jsonwebtoken";
+import User from "../model/userModel.js";
+import { decrypt } from "../utils/crypto.js";
 
 const router = express.Router();
 
@@ -18,11 +21,27 @@ router.get("/", async (req, res) => {
           .map((item) => item.trim())
           .filter(Boolean)
       : [];
+
+    let githubToken = null;
+    const { token } = req.cookies;
+    if (token) {
+      try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        const user = await User.findById(decoded.userId).select("+githubAccessToken");
+        if (user && user.githubAccessToken) {
+          githubToken = decrypt(user.githubAccessToken);
+        }
+      } catch (_err) {
+        // Ignore invalid tokens for recommendations
+      }
+    }
+
     const results = await getRecommendations({
       stack: userStack,
       level,
       search,
       history: historyTerms,
+      githubToken,
     });
 
     res.json({

--- a/backend/services/recommendationService.js
+++ b/backend/services/recommendationService.js
@@ -5,19 +5,21 @@ const REPO_OWNER = process.env.GITHUB_REPO_OWNER || "Nsanjayboruds";
 const REPO_NAME = process.env.GITHUB_REPO_NAME || "RIVETO";
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
-function getGithubHeaders() {
+function getGithubHeaders(githubToken = null) {
   const headers = {
     Accept: "application/vnd.github+json",
   };
 
-  if (GITHUB_TOKEN) {
+  if (githubToken) {
+    headers.Authorization = `token ${githubToken}`;
+  } else if (GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
   }
 
   return headers;
 }
 
-async function fetchIssues() {
+async function fetchIssues(githubToken = null) {
   const res = await axios.get(
     `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/issues`,
     {
@@ -27,7 +29,7 @@ async function fetchIssues() {
         sort: "updated",
         direction: "desc",
       },
-      headers: getGithubHeaders(),
+      headers: getGithubHeaders(githubToken),
     },
   );
 
@@ -83,8 +85,9 @@ async function getRecommendations({
   level = "all",
   search = "",
   history = [],
+  githubToken = null,
 }) {
-  const issues = await fetchIssues();
+  const issues = await fetchIssues(githubToken);
   const historyTerms = Array.isArray(history)
     ? history
     : String(history)

--- a/backend/utils/crypto.js
+++ b/backend/utils/crypto.js
@@ -1,0 +1,32 @@
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-cbc";
+const SECRET = process.env.JWT_SECRET || "fallback_secret_key_for_oauth";
+
+// Generate a 32-byte key from our JWT_SECRET
+const KEY = crypto.createHash("sha256").update(SECRET).digest();
+
+export function encrypt(text) {
+  if (!text) return text;
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
+  let encrypted = cipher.update(text, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  return `${iv.toString("hex")}:${encrypted}`;
+}
+
+export function decrypt(text) {
+  if (!text) return text;
+  try {
+    const [ivHex, encryptedHex] = text.split(":");
+    if (!ivHex || !encryptedHex) return "";
+    const iv = Buffer.from(ivHex, "hex");
+    const decipher = crypto.createDecipheriv(ALGORITHM, KEY, iv);
+    let decrypted = decipher.update(encryptedHex, "hex", "utf8");
+    decrypted += decipher.final("utf8");
+    return decrypted;
+  } catch (error) {
+    console.error("Decryption failed:", error);
+    return "";
+  }
+}

--- a/frontend/src/components/IssueRecommendations.jsx
+++ b/frontend/src/components/IssueRecommendations.jsx
@@ -26,6 +26,26 @@ export default function IssueRecommendations() {
   const [stack, setStack] = useState([]);
   const [history, setHistory] = useState('');
   const [retryCount, setRetryCount] = useState(0);
+  const [githubProfile, setGithubProfile] = useState(null);
+  const [checkingGithub, setCheckingGithub] = useState(true);
+
+  useEffect(() => {
+    const fetchGithubProfile = async () => {
+      try {
+        const res = await apiConfig.get('/auth/github/profile');
+        if (res.data && res.data.connected) {
+          setGithubProfile(res.data);
+        } else {
+          setGithubProfile(null);
+        }
+      } catch (err) {
+        console.error('Error fetching github profile:', err);
+      } finally {
+        setCheckingGithub(false);
+      }
+    };
+    fetchGithubProfile();
+  }, []);
 
   const toggleStack = (tech) => {
     setStack((prev) =>
@@ -100,6 +120,64 @@ export default function IssueRecommendations() {
             Find beginner-friendly and relevant GitHub issues ranked by label
             signals, stack matching, and contribution history keywords.
           </p>
+
+          {/* GitHub OAuth Connection Status */}
+          <div className="mt-6 border-t border-slate-100 pt-6 dark:border-slate-800/60">
+            {checkingGithub ? (
+              <div className="flex items-center space-x-2 text-sm text-slate-500">
+                <svg className="animate-spin h-4 w-4 text-cyan-500" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                <span>Checking connection...</span>
+              </div>
+            ) : githubProfile && githubProfile.connected ? (
+              <div className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/40 p-4 dark:border-emerald-950/40 dark:bg-emerald-950/10">
+                <div className="flex items-center space-x-3">
+                  <img
+                    src={githubProfile.avatar_url}
+                    alt={githubProfile.login}
+                    className="h-10 w-10 rounded-full border border-emerald-200 shadow-sm dark:border-emerald-800"
+                  />
+                  <div>
+                    <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                      Connected to GitHub
+                    </h4>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Logged in as <span className="font-medium text-emerald-600 dark:text-emerald-400">@{githubProfile.login}</span> • {githubProfile.public_repos} public repos
+                    </p>
+                  </div>
+                </div>
+                <span className="flex h-2 w-2 relative">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
+                </span>
+              </div>
+            ) : (
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 rounded-2xl border border-slate-100 bg-slate-50/40 p-4 dark:border-slate-800/40 dark:bg-slate-900/10">
+                <div>
+                  <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Personalize recommendations
+                  </h4>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Connect your GitHub account to bypass rate limits and match issues to your repositories.
+                  </p>
+                </div>
+                <button
+                  onClick={() => {
+                    const backendBaseUrl = apiConfig.defaults.baseURL.replace(/\/api$/, '');
+                    window.location.href = `${backendBaseUrl}/api/auth/github`;
+                  }}
+                  className="inline-flex items-center justify-center space-x-2 rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:bg-slate-800 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2 dark:bg-cyan-600 dark:hover:bg-cyan-500 dark:focus:ring-cyan-600 dark:focus:ring-offset-slate-900"
+                >
+                  <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24">
+                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.11.82-.26.82-.577v-2.234c-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.82 1.102.82 2.222v3.293c0 .319.22.694.825.576C20.565 21.795 24 17.3 24 12c0-6.63-5.37-12-12-12z" />
+                  </svg>
+                  <span>Connect GitHub</span>
+                </button>
+              </div>
+            )}
+          </div>
 
           <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             <label className="xl:col-span-2">


### PR DESCRIPTION
# Pull Request

## Summary
Integrates GitHub OAuth 2.0 connection and personalization in the developer recommendations portal of RIVETO. This allows users to connect their personal GitHub accounts, bypassing shared backend API rate limits and enabling tailored issue recommendations.

## Description
- **Backend Auth Routes**: Added `/api/auth/github` and `/api/auth/github/callback` routes using OAuth 2.0 flow to retrieve and store user access tokens, and `/api/auth/github/profile` to retrieve user information from the GitHub API.
- **Token Storage & Encryption**: Introduced an AES-256-CBC encryption helper using Node's native `crypto` module to securely store user credentials in the database, adding `githubAccessToken` to `userModel`.
- **Personalized Recommendations**: Updated the recommendation service to verify, decrypt, and pass the user's personal GitHub token under headers (falling back to `GITHUB_TOKEN` if not authenticated).
- **UI Enhancements**: Added an animated, modern "Connect GitHub" action button and a synchronized Profile Card showing connected status (username, avatar, repository count) to `IssueRecommendations.jsx`.

## Related Issue
Fixes #479

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] Documentation updated if required